### PR TITLE
chore: add `pypi-test-*` envs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,13 @@ If you want to contribute by submitting code, this section will explain how to s
 1. We use [hatch](https://hatch.pypa.io/) as the dependency and environment manager. Make sure you install it via one of the methods described [here](https://hatch.pypa.io/latest/install/). 
 2. We use [lefthook](https://github.com/evilmartians/lefthook/) for Git hooks management. The first time you clone the repo, run `lefthook install` to setup the git hooks.
 
-Hatch will manage your environments for you. Check out the list of available environments in [`pyproject.toml`](./pyproject.toml). You probably want to use the `dev` environment by running `hatch shell dev`.
+Hatch will manage your environments for you. Check out the list of available environments in [`pyproject.toml`](./pyproject.toml). Here follows a brief explanation of what they are for:
+- `default`: run only basic scripts, no dependencies installed
+- `test`: SDK and test dependencies installed
+- `pypi-test-*`: install the SDK from `https://test.pypi.org/simple/` to make sure our build and publish pipelines work before actually publishing the real package
+- `dev`: install SDK dependencies and other tools needed during dev such as `ruff` and `basedpyright`.
+
+For most use cases, you probably want to use the `dev` environment by running `hatch shell dev`.
 
 
 ### Upgrading dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ features = [
   "dev-main",
   "dev-test"
 ]
-
 [tool.hatch.envs.dev.scripts]
 fetch-schema = "python tests/fetch_schema.py > tests/server_schema.gql"
 
@@ -70,12 +69,26 @@ features = [
   "async",
   "dev-test"
 ]
-
 [tool.hatch.envs.test.scripts]
 run = "pytest --server-schema tests/server_schema.gql"
-
 [[tool.hatch.envs.test.matrix]]
 python = ["3.9", "3.10", "3.11", "3.12"]
+
+[tool.hatch.envs.pypi-test-sync]
+dependencies = [
+  "dbt-sl-sdk[sync]"
+]
+[tool.hatch.envs.pypi-test-sync.env-vars]
+PIP_INDEX_URL = "https://test.pypi.org/simple/"
+PIP_EXTRA_INDEX_URL = "https://pypi.org/simple/"
+
+[tool.hatch.envs.pypi-test-async]
+dependencies = [
+  "dbt-sl-sdk[async]"
+]
+[tool.hatch.envs.pypi-test-async.env-vars]
+PIP_INDEX_URL = "https://test.pypi.org/simple/"
+PIP_EXTRA_INDEX_URL = "https://pypi.org/simple/"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
This commit adds two new environments to hatch which install the SDK from the test PyPI repo at `https://test.pypi.org/simple/`. This is to make sure our build and publish pipelines work whenever we make a change to them.