### PR TITLE
refactor(defaults): better defaults

### DIFF
--- a/dbtsl/__init__.py
+++ b/dbtsl/__init__.py
@@ -13,6 +13,4 @@ except ImportError:
 
     SemanticLayerClient = err_factory
 
-__all__ = [
-    "SemanticLayerClient"
-]
+__all__ = ["SemanticLayerClient"]

--- a/dbtsl/api/adbc/client/asyncio.py
+++ b/dbtsl/api/adbc/client/asyncio.py
@@ -6,7 +6,7 @@ import pyarrow as pa
 from typing_extensions import Self, Unpack
 
 from dbtsl.api.adbc.client.base import BaseADBCClient
-from dbtsl.api.adbc.protocol import ADBCProtocol, QueryParameters
+from dbtsl.api.adbc.protocol import QueryParameters
 
 
 class AsyncADBCClient(BaseADBCClient):
@@ -52,7 +52,7 @@ class AsyncADBCClient(BaseADBCClient):
 
     async def query(self, **query_params: Unpack[QueryParameters]) -> pa.Table:
         """Query for a dataframe in the Semantic Layer."""
-        query_sql = ADBCProtocol.get_query_sql(query_params)
+        query_sql = self.PROTOCOL.get_query_sql(query_params)
 
         # NOTE: We don't need to wrap this in a `loop.run_in_executor` since
         # just creating the cursor object doesn't perform any blocking IO.

--- a/dbtsl/api/adbc/client/base.py
+++ b/dbtsl/api/adbc/client/base.py
@@ -8,11 +8,15 @@ from adbc_driver_flightsql.dbapi import connect as adbc_connect
 from adbc_driver_manager import AdbcStatusCode, ProgrammingError
 
 import dbtsl.env as env
+from dbtsl.api.adbc.protocol import ADBCProtocol
 from dbtsl.error import AuthError, QueryFailedError
 
 
 class BaseADBCClient:
     """Base class for the ADBC API client."""
+
+    PROTOCOL = ADBCProtocol
+    DEFAULT_URL_FORMAT = env.DEFAULT_ADBC_URL_FORMAT
 
     def __init__(  # noqa: D107
         self,
@@ -21,7 +25,7 @@ class BaseADBCClient:
         auth_token: str,
         url_format: Optional[str] = None,
     ) -> None:
-        url_format = url_format or env.DEFAULT_ADBC_URL_FORMAT
+        url_format = url_format or self.DEFAULT_URL_FORMAT
         self._conn_str = url_format.format(server_host=server_host)
         self._environment_id = environment_id
         self._auth_token = auth_token

--- a/dbtsl/api/adbc/client/sync.py
+++ b/dbtsl/api/adbc/client/sync.py
@@ -5,7 +5,7 @@ import pyarrow as pa
 from typing_extensions import Self, Unpack
 
 from dbtsl.api.adbc.client.base import BaseADBCClient
-from dbtsl.api.adbc.protocol import ADBCProtocol, QueryParameters
+from dbtsl.api.adbc.protocol import QueryParameters
 
 
 class SyncADBCClient(BaseADBCClient):
@@ -48,7 +48,7 @@ class SyncADBCClient(BaseADBCClient):
 
     def query(self, **query_params: Unpack[QueryParameters]) -> pa.Table:
         """Query for a dataframe in the Semantic Layer."""
-        query_sql = ADBCProtocol.get_query_sql(query_params)
+        query_sql = self.PROTOCOL.get_query_sql(query_params)
 
         with self._conn.cursor() as cur:
             try:

--- a/dbtsl/api/graphql/client/base.py
+++ b/dbtsl/api/graphql/client/base.py
@@ -28,6 +28,9 @@ class BaseGraphQLClient(Generic[TTransport, TSession]):
     will choose if IO is sync or async.
     """
 
+    PROTOCOL = GraphQLProtocol
+    DEFAULT_URL_FORMAT = env.DEFAULT_GRAPHQL_URL_FORMAT
+
     @classmethod
     def _default_backoff(cls) -> ExponentialBackoff:
         """Get the default backoff behavior when polling."""
@@ -46,7 +49,7 @@ class BaseGraphQLClient(Generic[TTransport, TSession]):
     ):
         self.environment_id = environment_id
 
-        url_format = url_format or env.DEFAULT_GRAPHQL_URL_FORMAT
+        url_format = url_format or self.DEFAULT_URL_FORMAT
         server_url = url_format.format(server_host=server_host)
 
         transport = self._create_transport(url=server_url, headers={"authorization": f"bearer {auth_token}"})
@@ -87,7 +90,7 @@ class BaseGraphQLClient(Generic[TTransport, TSession]):
 
     def __getattr__(self, attr: str) -> Any:
         """Run an underlying GraphQLOperation if it exists in GraphQLProtocol."""
-        op = getattr(GraphQLProtocol, attr)
+        op = getattr(self.PROTOCOL, attr)
         if op is None:
             raise AttributeError()
 


### PR DESCRIPTION
This commit moves some constants over from `env` to their own classes, and makes the clients have a `PROTOCOL` instance in them. This will make it easier to extend further later.