### PR TITLE
fix: import error on 3.9

### DIFF
--- a/.changes/unreleased/Fixes-20240618-124639.yaml
+++ b/.changes/unreleased/Fixes-20240618-124639.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Fix import error on 3.9
+time: 2024-06-18T12:46:39.22244+02:00

--- a/.github/workflows/changelog-check.yaml
+++ b/.github/workflows/changelog-check.yaml
@@ -11,26 +11,27 @@ jobs:
     if: "!startsWith(github.event.head_commit.message, 'version:')"
     steps:
       - uses: actions/checkout@v4
-      - run: git fetch --depth=1 origin ${{ github.event.pull_request.base.name }}
+      - run: git fetch --depth=1 origin main
 
       - name: Setup Python ${{ env.PYTHON_VERSION }} environment
         uses: ./.github/actions/setup-python-env
 
       - name: Check for changes
         run: |
-          ALL_CHANGES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }})
+          ALL_CHANGES=$(git diff --name-only HEAD origin/main)
 
-          CHANGIE=$(echo "$ALL_CHANGES" | grep -E "\.changes/.*\.md")
+          CHANGIE=$(echo "$ALL_CHANGES" | grep -E "\.changes/unreleased/.*\.yaml" || true)
           if [ "$CHANGIE" == "" ]; then
-            echo "No files added to `.changes/`. Make sure you run `changie new`."
+            echo "No files added to '.changes/unreleased/'. Make sure you run 'changie new'."
             exit 1
           fi
 
-          CHANGELOG=$(echo "$ALL_CHANGES" | grep "CHANGELOG.md")
+          CHANGELOG=$(echo "$ALL_CHANGES" | grep -E "CHANGELOG\.md" || true)
           if [ "$CHANGELOG" != "" ]; then
-            echo "Don't edit 'CHANGELOG.md' manually nor run `changie merge`."
+            echo "Don't edit 'CHANGELOG.md' manually nor run 'changie merge'."
             exit 1
           fi
+
 
       - name: Get latest changie version
         id: latest

--- a/dbtsl/api/graphql/client/sync.py
+++ b/dbtsl/api/graphql/client/sync.py
@@ -1,9 +1,10 @@
 from contextlib import contextmanager
-from typing import Dict, Iterator, Optional, Self, override
+from typing import Dict, Iterator, Optional
 
 from gql import gql
 from gql.client import SyncClientSession
 from gql.transport.requests import RequestsHTTPTransport
+from typing_extensions import Self, override
 
 from dbtsl.api.graphql.client.base import BaseGraphQLClient
 from dbtsl.api.graphql.protocol import (

--- a/dbtsl/client/sync.py
+++ b/dbtsl/client/sync.py
@@ -1,5 +1,7 @@
 from contextlib import contextmanager
-from typing import Iterator, Self
+from typing import Iterator
+
+from typing_extensions import Self
 
 from dbtsl.api.adbc.client.sync import SyncADBCClient
 from dbtsl.api.graphql.client.sync import SyncGraphQLClient

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ fetch-schema = "python scripts/fetch_schema.py > tests/server_schema.gql"
 [tool.hatch.envs.test]
 features = [
   "async",
+  "sync",
   "dev-test"
 ]
 [tool.hatch.envs.test.scripts]

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,16 @@
+import importlib
+import pkgutil
+
+import dbtsl
+
+
+def test_imports() -> None:
+    """Test that nothing raises import error.
+
+    This is a sanity check test to make sure we have no wrong imports or
+    anything else that might raise an error. This might catch errors such as
+    importing something from `typing` when we should be importing from `typing_extensions`
+    in an older version of Python.
+    """
+    for pkg in pkgutil.walk_packages(path=dbtsl.__path__, prefix=f"{dbtsl.__name__}."):
+        importlib.import_module(pkg.name)


### PR DESCRIPTION
The previous version of the package was raising errors on Python 3.9 due to importing `Self` from `typing`, which was introduced in 3.10. I changed it to `typing_extensions`, and added a test for importing all modules to avoid errors like this in the future.