### PR TITLE
chore(ruff): known-first-party config was wrong

### DIFF
--- a/.changes/unreleased/Chore-20240618-132741.yaml
+++ b/.changes/unreleased/Chore-20240618-132741.yaml
@@ -1,0 +1,3 @@
+kind: Chore
+body: Known first party was wrong for Ruff
+time: 2024-06-18T13:27:41.272492+02:00

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,7 @@ unfixable = []
 convention = "google"
 
 [tool.ruff.lint.isort]
-known-first-party = ["dbt_sl_client"]
+known-first-party = ["dbtsl"]
 
 [tool.ruff.lint.per-file-ignores]
 # Ignore docs for test files


### PR DESCRIPTION
That config was using the old name.