### PR TITLE
internal: add `user-agent` header for telemetry

### DIFF
--- a/.changes/unreleased/Under the Hood-20240618-163932.yaml
+++ b/.changes/unreleased/Under the Hood-20240618-163932.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Add `user-agent` header for telemetry
+time: 2024-06-18T16:39:32.592231+02:00

--- a/.lefthook/commit-msg/template-checker
+++ b/.lefthook/commit-msg/template-checker
@@ -8,7 +8,7 @@
 
 INPUT_FILE=$1
 
-PATTERN="^((chore|ci|docs|feat|fix|perf|refactor|revert|test|version)(\([a-z0-9\-]+\))?(!)?(: (.*\s*)*))"
+PATTERN="^((chore|ci|docs|feat|fix|internal|perf|refactor|revert|test|version)(\([a-z0-9\-]+\))?(!)?(: (.*\s*)*))"
 grep -E "$PATTERN" $INPUT_FILE
 MATCH=$?
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,17 @@ polars_df = pl.from_arrow(arrow_table)
 Check out our [usage examples](./examples/) to learn more.
 
 
+### Disabling telemetry
+
+By default, dbt the SDK sends some [platform-related information](./dbtsl/env.py) to dbt Labs. If you'd like to opt out, do
+```python
+from dbtsl.env import PLATFORM
+PLATFORM.anonymous = True
+
+# ... initialize client
+```
+
+
 ## Contributing
 
 If you're interested in contributing to this project, check out our [contribution guidelines](./CONTRIBUTING.md).

--- a/dbtsl/api/adbc/client/base.py
+++ b/dbtsl/api/adbc/client/base.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from contextlib import AbstractContextManager
-from typing import Generic, Optional, Protocol, TypeVar, Union
+from typing import Dict, Generic, Optional, Protocol, TypeVar, Union
 
 from adbc_driver_flightsql import DatabaseOptions
 from adbc_driver_flightsql.dbapi import Connection
@@ -17,6 +17,13 @@ class BaseADBCClient:
 
     PROTOCOL = ADBCProtocol
     DEFAULT_URL_FORMAT = env.DEFAULT_ADBC_URL_FORMAT
+
+    @classmethod
+    def _extra_db_kwargs(cls) -> Dict[str, str]:
+        return {
+            DatabaseOptions.WITH_COOKIE_MIDDLEWARE.value: "true",
+            f"{DatabaseOptions.RPC_CALL_HEADER_PREFIX.value}user-agent": env.PLATFORM.user_agent,
+        }
 
     def __init__(  # noqa: D107
         self,
@@ -38,7 +45,7 @@ class BaseADBCClient:
             db_kwargs={
                 DatabaseOptions.AUTHORIZATION_HEADER.value: f"Bearer {self._auth_token}",
                 f"{DatabaseOptions.RPC_CALL_HEADER_PREFIX.value}environmentid": str(self._environment_id),
-                DatabaseOptions.WITH_COOKIE_MIDDLEWARE.value: "true",
+                **self._extra_db_kwargs(),
             },
         )
 

--- a/dbtsl/api/graphql/client/base.py
+++ b/dbtsl/api/graphql/client/base.py
@@ -40,6 +40,12 @@ class BaseGraphQLClient(Generic[TTransport, TSession]):
             timeout_ms=90000,
         )
 
+    @classmethod
+    def _extra_headers(cls) -> Dict[str, str]:
+        return {
+            "user-agent": env.PLATFORM.user_agent,
+        }
+
     def __init__(  # noqa: D107
         self,
         server_host: str,
@@ -52,7 +58,11 @@ class BaseGraphQLClient(Generic[TTransport, TSession]):
         url_format = url_format or self.DEFAULT_URL_FORMAT
         server_url = url_format.format(server_host=server_host)
 
-        transport = self._create_transport(url=server_url, headers={"authorization": f"bearer {auth_token}"})
+        headers = {
+            "authorization": f"bearer {auth_token}",
+            **self._extra_headers(),
+        }
+        transport = self._create_transport(url=server_url, headers=headers)
         self._gql = Client(transport=transport)
 
         self._gql_session_unsafe: Union[TSession, None] = None

--- a/dbtsl/env.py
+++ b/dbtsl/env.py
@@ -1,9 +1,40 @@
 """All global environment configurations for the SDK live here."""
 
 import os
+import platform as pl
+from dataclasses import dataclass
+
+from dbtsl.__about__ import VERSION as DBTSL_VERSION
 
 DEFAULT_GRAPHQL_URL_FORMAT = "https://{server_host}/api/graphql"
 DEFAULT_ADBC_URL_FORMAT = "grpc+tls://{server_host}:443"
 
 GRAPHQL_URL_FORMAT = os.environ.get("DBT_SL_GRAPHQL_URL_FORMAT", DEFAULT_GRAPHQL_URL_FORMAT)
 ADBC_URL_FORMAT = os.environ.get("DBT_SL_ADBC_URL_FORMAT", DEFAULT_ADBC_URL_FORMAT)
+
+
+@dataclass
+class Platform:
+    """Identify the current platform."""
+
+    anonymous = False
+
+    arch = pl.machine()
+    os = pl.system()
+    py_impl = pl.python_implementation()
+    py_version = pl.python_version()
+
+    @property
+    def identity(self) -> str:
+        """Return the identity string of the current platform."""
+        if self.anonymous:
+            return "anonymous"
+        return f"{self.os} ({self.arch}) / Python {self.py_version} ({self.py_impl})"
+
+    @property
+    def user_agent(self) -> str:
+        """Get a User-Agent header based on the current platform."""
+        return f"dbt-sl-sdk-python {DBTSL_VERSION} / {self.identity}"
+
+
+PLATFORM = Platform()


### PR DESCRIPTION
This commit adds a `User-Agent` header for telemetry so that we know which requests are coming from the SDK.