### PR TITLE
fix: backoff was not using `exp_factor`

### DIFF
--- a/.changes/unreleased/Fixes-20240618-180037.yaml
+++ b/.changes/unreleased/Fixes-20240618-180037.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Fix `backoff` not using `exp_factor`
+time: 2024-06-18T18:00:37.645589+02:00

--- a/dbtsl/backoff.py
+++ b/dbtsl/backoff.py
@@ -31,4 +31,4 @@ class ExponentialBackoff:
             if elapsed_ms > self.timeout_ms:
                 raise TimeoutError()
 
-            yield min(int(self.base_interval_ms * 1.15**i), self.max_interval_ms)
+            yield min(int(self.base_interval_ms * self.exp_factor**i), self.max_interval_ms)


### PR DESCRIPTION
`ExponentialBackoff` was had `exp_factor` hardcoded to 1.15.