### PR TITLE
refactor: change how clients poll and create queries

### DIFF
--- a/.changes/unreleased/Under the Hood-20240620-130850.yaml
+++ b/.changes/unreleased/Under the Hood-20240620-130850.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Change how clients create and poll for query results
+time: 2024-06-20T13:08:50.067409+02:00

--- a/dbtsl/api/graphql/client/asyncio.py
+++ b/dbtsl/api/graphql/client/asyncio.py
@@ -10,7 +10,6 @@ from typing_extensions import Self, Unpack, override
 
 from dbtsl.api.graphql.client.base import BaseGraphQLClient
 from dbtsl.api.graphql.protocol import (
-    GetQueryResultVariables,
     ProtocolOperation,
     TResponse,
     TVariables,
@@ -69,17 +68,12 @@ class AsyncGraphQLClient(BaseGraphQLClient[AIOHTTPTransport, AsyncClientSession]
         variables = op.get_request_variables(environment_id=self.environment_id, **kwargs)
         gql_query = gql(raw_query)
 
-        res = await self._gql_session.execute(gql_query, variable_values=variables)
+        try:
+            res = await self._gql_session.execute(gql_query, variable_values=variables)
+        except Exception as err:
+            raise self._refine_err(err)
 
         return op.parse_response(res)
-
-    async def _create_query(self, **params: Unpack[QueryParameters]) -> QueryId:
-        """Create a query that will run asynchronously."""
-        return await self._run(self.PROTOCOL.create_query, **params)  # type: ignore
-
-    async def _get_query_result(self, **params: Unpack[GetQueryResultVariables]) -> QueryResult:
-        """Fetch a query's results'."""
-        return await self._run(self.PROTOCOL.get_query_result, **params)  # type: ignore
 
     async def _poll_until_complete(
         self,
@@ -97,7 +91,7 @@ class AsyncGraphQLClient(BaseGraphQLClient[AIOHTTPTransport, AsyncClientSession]
         for sleep_ms in backoff.iter_ms():
             # TODO: add timeout param to all requests because technically the API could hang and
             # then we don't respect timeout.
-            qr = await self._get_query_result(query_id=query_id, page_num=1)
+            qr = await self.get_query_result(query_id=query_id, page_num=1)
             if qr.status in (QueryStatus.SUCCESSFUL, QueryStatus.FAILED):
                 return qr
 
@@ -108,7 +102,7 @@ class AsyncGraphQLClient(BaseGraphQLClient[AIOHTTPTransport, AsyncClientSession]
 
     async def query(self, **params: Unpack[QueryParameters]) -> "pa.Table":
         """Query the Semantic Layer."""
-        query_id = await self._create_query(**params)
+        query_id = await self.create_query(**params)
         first_page_results = await self._poll_until_complete(query_id)
         if first_page_results.status != QueryStatus.SUCCESSFUL:
             raise QueryFailedError()
@@ -119,7 +113,7 @@ class AsyncGraphQLClient(BaseGraphQLClient[AIOHTTPTransport, AsyncClientSession]
             return first_page_results.result_table
 
         tasks = [
-            self._get_query_result(query_id=query_id, page_num=page)
+            self.get_query_result(query_id=query_id, page_num=page)
             for page in range(2, first_page_results.total_pages + 1)
         ]
         all_page_results = [first_page_results] + await asyncio.gather(*tasks)

--- a/dbtsl/api/graphql/client/asyncio.py
+++ b/dbtsl/api/graphql/client/asyncio.py
@@ -1,6 +1,6 @@
 import asyncio
 from contextlib import asynccontextmanager
-from typing import AsyncIterator, Dict, Optional, TypeVar
+from typing import AsyncIterator, Dict, Optional
 
 import pyarrow as pa
 from gql import gql
@@ -10,9 +10,9 @@ from typing_extensions import Self, Unpack, override
 
 from dbtsl.api.graphql.client.base import BaseGraphQLClient
 from dbtsl.api.graphql.protocol import (
-    JobStatusResult,
-    JobStatusVariables,
     ProtocolOperation,
+    TJobStatusResult,
+    TJobStatusVariables,
     TResponse,
     TVariables,
 )
@@ -20,9 +20,6 @@ from dbtsl.api.shared.query_params import QueryParameters
 from dbtsl.backoff import ExponentialBackoff
 from dbtsl.error import QueryFailedError
 from dbtsl.models.query import QueryId, QueryStatus
-
-TJobStatusVariables = TypeVar("TJobStatusVariables", bound=JobStatusVariables, covariant=True)
-TJobStatusResult = TypeVar("TJobStatusResult", bound=JobStatusResult, covariant=True)
 
 
 class AsyncGraphQLClient(BaseGraphQLClient[AIOHTTPTransport, AsyncClientSession]):

--- a/dbtsl/api/graphql/client/base.py
+++ b/dbtsl/api/graphql/client/base.py
@@ -10,9 +10,6 @@ from gql.transport.exceptions import TransportQueryError
 import dbtsl.env as env
 from dbtsl.api.graphql.protocol import (
     GraphQLProtocol,
-    ProtocolOperation,
-    TResponse,
-    TVariables,
 )
 from dbtsl.backoff import ExponentialBackoff
 from dbtsl.error import AuthError
@@ -75,9 +72,9 @@ class BaseGraphQLClient(Generic[TTransport, TSession]):
     def _refine_err(self, err: Exception) -> Exception:
         """Refine a generic exception that might have happened during `_run`."""
         if (
-            isinstance(err, TransportQueryError) and
-            err.errors is not None and
-            err.errors[0]["message"] == "User is not authorized"
+            isinstance(err, TransportQueryError)
+            and err.errors is not None
+            and err.errors[0]["message"] == "User is not authorized"
         ):
             return AuthError(err.args)
 

--- a/dbtsl/api/graphql/client/base.py
+++ b/dbtsl/api/graphql/client/base.py
@@ -72,20 +72,16 @@ class BaseGraphQLClient(Generic[TTransport, TSession]):
         """Create the underlying transport to be used by the gql Client."""
         raise NotImplementedError()
 
-    @abstractmethod
-    def _run(self, op: ProtocolOperation[TVariables, TResponse], **kwargs: TVariables) -> TResponse:
-        raise NotImplementedError()
+    def _refine_err(self, err: Exception) -> Exception:
+        """Refine a generic exception that might have happened during `_run`."""
+        if (
+            isinstance(err, TransportQueryError) and
+            err.errors is not None and
+            err.errors[0]["message"] == "User is not authorized"
+        ):
+            return AuthError(err.args)
 
-    def _run_err_wrapper(self, op: ProtocolOperation[TVariables, TResponse], **kwargs: TVariables) -> TResponse:
-        try:
-            return self._run(op, **kwargs)
-        except TransportQueryError as err:
-            # TODO: we should probably return an error type that has an Enum from GraphQL
-            # instead of depending on error messages
-            if err.errors is not None and err.errors[0]["message"] == "User is not authorized":
-                raise AuthError(err.args)
-
-            raise err
+        return err
 
     @property
     def _gql_session(self) -> TSession:
@@ -110,7 +106,7 @@ class BaseGraphQLClient(Generic[TTransport, TSession]):
             raise AttributeError()
 
         return functools.partial(
-            self._run_err_wrapper,
+            self._run,
             op=op,
         )
 

--- a/dbtsl/api/graphql/client/sync.py
+++ b/dbtsl/api/graphql/client/sync.py
@@ -10,7 +10,6 @@ from typing_extensions import Self, Unpack, override
 
 from dbtsl.api.graphql.client.base import BaseGraphQLClient
 from dbtsl.api.graphql.protocol import (
-    GetQueryResultVariables,
     ProtocolOperation,
     TResponse,
     TVariables,
@@ -69,17 +68,12 @@ class SyncGraphQLClient(BaseGraphQLClient[RequestsHTTPTransport, SyncClientSessi
         variables = op.get_request_variables(environment_id=self.environment_id, **kwargs)
         gql_query = gql(raw_query)
 
-        res = self._gql_session.execute(gql_query, variable_values=variables)
+        try:
+            res = self._gql_session.execute(gql_query, variable_values=variables)
+        except Exception as err:
+            raise self._refine_err(err)
 
         return op.parse_response(res)
-
-    def _create_query(self, **params: Unpack[QueryParameters]) -> QueryId:
-        """Create a query that will run asynchronously."""
-        return self._run(self.PROTOCOL.create_query, **params)  # type: ignore
-
-    def _get_query_result(self, **params: Unpack[GetQueryResultVariables]) -> QueryResult:
-        """Fetch a query's results'."""
-        return self._run(self.PROTOCOL.get_query_result, **params)  # type: ignore
 
     def _poll_until_complete(
         self,
@@ -97,7 +91,7 @@ class SyncGraphQLClient(BaseGraphQLClient[RequestsHTTPTransport, SyncClientSessi
         for sleep_ms in backoff.iter_ms():
             # TODO: add timeout param to all requests because technically the API could hang and
             # then we don't respect timeout.
-            qr = self._get_query_result(query_id=query_id, page_num=1)
+            qr = self.get_query_result(query_id=query_id, page_num=1)
             if qr.status in (QueryStatus.SUCCESSFUL, QueryStatus.FAILED):
                 return qr
 
@@ -108,7 +102,7 @@ class SyncGraphQLClient(BaseGraphQLClient[RequestsHTTPTransport, SyncClientSessi
 
     def query(self, **params: Unpack[QueryParameters]) -> "pa.Table":
         """Query the Semantic Layer."""
-        query_id = self._create_query(**params)
+        query_id = self.create_query(**params)
         first_page_results = self._poll_until_complete(query_id)
         if first_page_results.status != QueryStatus.SUCCESSFUL:
             raise QueryFailedError()
@@ -119,7 +113,7 @@ class SyncGraphQLClient(BaseGraphQLClient[RequestsHTTPTransport, SyncClientSessi
             return first_page_results.result_table
 
         results = [
-            self._get_query_result(query_id=query_id, page_num=page)
+            self.get_query_result(query_id=query_id, page_num=page)
             for page in range(2, first_page_results.total_pages + 1)
         ]
         all_page_results = [first_page_results] + results

--- a/dbtsl/api/graphql/protocol.py
+++ b/dbtsl/api/graphql/protocol.py
@@ -1,15 +1,33 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Generic, List, Mapping, TypedDict, TypeVar
+from typing import Any, Dict, Generic, List, Mapping, Protocol, TypedDict, TypeVar
 
 from mashumaro.codecs.basic import decode as decode_to_dataclass
 from typing_extensions import NotRequired, override
 
 from dbtsl.api.shared.query_params import QueryParameters
 from dbtsl.models import Dimension, Measure, Metric
-from dbtsl.models.query import QueryId, QueryResult
+from dbtsl.models.query import QueryId, QueryResult, QueryStatus
+
+
+class JobStatusVariables(TypedDict):
+    """Variables of operations that will get a job's status."""
+
+    query_id: QueryId
+
+
+class JobStatusResult(Protocol):
+    """Result of operations that fetch a job's status."""
+
+    @property
+    def status(self) -> QueryStatus:
+        """The job status."""
+        raise NotImplementedError()
+
 
 TVariables = TypeVar("TVariables", bound=Mapping[str, Any])
-TResponse = TypeVar("TResponse")
+# Need to make TResponse covariant otherwise we can't annotate something like
+# def func(a: ProtocolOperation[JobStatusVariables, JobStatusResult]) -> JobStatusResult:
+TResponse = TypeVar("TResponse", covariant=True)
 
 
 class ProtocolOperation(Generic[TVariables, TResponse], ABC):

--- a/dbtsl/api/graphql/protocol.py
+++ b/dbtsl/api/graphql/protocol.py
@@ -24,6 +24,11 @@ class JobStatusResult(Protocol):
         raise NotImplementedError()
 
 
+TJobStatusVariables = TypeVar("TJobStatusVariables", bound=JobStatusVariables, covariant=True)
+
+TJobStatusResult = TypeVar("TJobStatusResult", bound=JobStatusResult, covariant=True)
+
+
 TVariables = TypeVar("TVariables", bound=Mapping[str, Any])
 # Need to make TResponse covariant otherwise we can't annotate something like
 # def func(a: ProtocolOperation[JobStatusVariables, JobStatusResult]) -> JobStatusResult:

--- a/tests/api/graphql/test_client.py
+++ b/tests/api/graphql/test_client.py
@@ -1,16 +1,19 @@
 import base64
 import io
-from unittest.mock import call
+from unittest.mock import AsyncMock, call
 
 import pyarrow as pa
 from pytest_mock import MockerFixture
 
 from dbtsl.api.graphql.client.asyncio import AsyncGraphQLClient
+from dbtsl.api.graphql.client.sync import SyncGraphQLClient
 from dbtsl.api.shared.query_params import QueryParameters
 from dbtsl.models.query import QueryId, QueryResult, QueryStatus
 
+# The following 2 tests are copies of each other since testing the same sync/async functionality is
+# a pain. I should probably find how to fix this later
 
-async def test_query_multiple_pages(mocker: MockerFixture) -> None:
+async def test_async_query_multiple_pages(mocker: MockerFixture) -> None:
     """Test that querying a dataframe with multiple pages works."""
     client = AsyncGraphQLClient(server_host="test", environment_id=0, auth_token="test")
 
@@ -20,7 +23,7 @@ async def test_query_multiple_pages(mocker: MockerFixture) -> None:
     )
 
     async def gqr_behavior(query_id: QueryId, page_num: int) -> QueryResult:
-        """Behaves like `_get_query_result` but without talking to any servers."""
+        """Behaves like `get_query_result` but without talking to any servers."""
         call_table = table.slice(offset=page_num - 1, length=1)
 
         byte_stream = io.BytesIO()
@@ -36,8 +39,8 @@ async def test_query_multiple_pages(mocker: MockerFixture) -> None:
             arrow_result=base64.b64encode(byte_stream.getvalue()).decode("utf-8"),
         )
 
-    cq_mock = mocker.patch.object(client, "_create_query", return_value=query_id)
-    gqr_mock = mocker.patch.object(client, "_get_query_result", side_effect=gqr_behavior)
+    cq_mock = mocker.patch.object(client, "create_query", return_value=query_id, new_callable=AsyncMock)
+    gqr_mock = mocker.patch.object(client, "get_query_result", side_effect=gqr_behavior, new_callable=AsyncMock)
 
     kwargs: QueryParameters = {"metrics": ["m1", "m2"], "group_by": ["gb"], "limit": 1}
 
@@ -46,6 +49,53 @@ async def test_query_multiple_pages(mocker: MockerFixture) -> None:
     cq_mock.assert_awaited_once_with(**kwargs)
 
     gqr_mock.assert_has_awaits(
+        [
+            call(query_id=query_id, page_num=1),
+            call(query_id=query_id, page_num=2),
+            call(query_id=query_id, page_num=3),
+            call(query_id=query_id, page_num=4),
+        ]
+    )
+
+    assert result_table.equals(table, check_metadata=True)
+
+
+def test_sync_query_multiple_pages(mocker: MockerFixture) -> None:
+    """Test that querying a dataframe with multiple pages works."""
+    client = SyncGraphQLClient(server_host="test", environment_id=0, auth_token="test")
+
+    query_id = QueryId("test-query-id")
+    table = pa.Table.from_arrays(
+        [pa.array([2, 4, 6, 100]), pa.array(["Chicken", "Dog", "Ant", "Centipede"])], names=["num_legs", "animal"]
+    )
+
+    def gqr_behavior(query_id: QueryId, page_num: int) -> QueryResult:
+        """Behaves like `get_query_result` but without talking to any servers."""
+        call_table = table.slice(offset=page_num - 1, length=1)
+
+        byte_stream = io.BytesIO()
+        with pa.ipc.new_stream(byte_stream, call_table.schema) as writer:
+            writer.write_table(call_table)
+
+        return QueryResult(
+            query_id=query_id,
+            status=QueryStatus.SUCCESSFUL,
+            sql=None,
+            error=None,
+            total_pages=len(table),
+            arrow_result=base64.b64encode(byte_stream.getvalue()).decode("utf-8"),
+        )
+
+    cq_mock = mocker.patch.object(client, "create_query", return_value=query_id)
+    gqr_mock = mocker.patch.object(client, "get_query_result", side_effect=gqr_behavior)
+
+    kwargs: QueryParameters = {"metrics": ["m1", "m2"], "group_by": ["gb"], "limit": 1}
+
+    result_table = client.query(**kwargs)
+
+    cq_mock.assert_called_once_with(**kwargs)
+
+    gqr_mock.assert_has_calls(
         [
             call(query_id=query_id, page_num=1),
             call(query_id=query_id, page_num=2),

--- a/tests/api/graphql/test_client.py
+++ b/tests/api/graphql/test_client.py
@@ -7,11 +7,15 @@ from pytest_mock import MockerFixture
 
 from dbtsl.api.graphql.client.asyncio import AsyncGraphQLClient
 from dbtsl.api.graphql.client.sync import SyncGraphQLClient
+from dbtsl.api.graphql.protocol import GraphQLProtocol, ProtocolOperation
 from dbtsl.api.shared.query_params import QueryParameters
 from dbtsl.models.query import QueryId, QueryResult, QueryStatus
 
 # The following 2 tests are copies of each other since testing the same sync/async functionality is
 # a pain. I should probably find how to fix this later
+#
+# These tests are so bad and test a bunch of internals, I hate my life
+
 
 async def test_async_query_multiple_pages(mocker: MockerFixture) -> None:
     """Test that querying a dataframe with multiple pages works."""
@@ -39,18 +43,34 @@ async def test_async_query_multiple_pages(mocker: MockerFixture) -> None:
             arrow_result=base64.b64encode(byte_stream.getvalue()).decode("utf-8"),
         )
 
+    async def run_behavior(op: ProtocolOperation, query_id: QueryId, page_num: int) -> QueryResult:
+        return await gqr_behavior(query_id, page_num)
+
     cq_mock = mocker.patch.object(client, "create_query", return_value=query_id, new_callable=AsyncMock)
-    gqr_mock = mocker.patch.object(client, "get_query_result", side_effect=gqr_behavior, new_callable=AsyncMock)
+
+    run_mock = AsyncMock(side_effect=run_behavior)
+    mocker.patch.object(client, "_run", new=run_mock)
+    gqr_mock = AsyncMock(side_effect=gqr_behavior)
+    mocker.patch.object(client, "get_query_result", new=gqr_mock)
+
+    gql_mock = mocker.patch.object(client, "_gql")
+    mocker.patch.object(gql_mock, "__aenter__", new_callable=AsyncMock)
+    mocker.patch("dbtsl.api.graphql.client.asyncio.isinstance", return_value=True)
 
     kwargs: QueryParameters = {"metrics": ["m1", "m2"], "group_by": ["gb"], "limit": 1}
-
-    result_table = await client.query(**kwargs)
+    async with client.session():
+        result_table = await client.query(**kwargs)
 
     cq_mock.assert_awaited_once_with(**kwargs)
 
+    run_mock.assert_has_awaits(
+        [
+            call(GraphQLProtocol.get_query_result, query_id=query_id, page_num=1),
+        ]
+    )
+
     gqr_mock.assert_has_awaits(
         [
-            call(query_id=query_id, page_num=1),
             call(query_id=query_id, page_num=2),
             call(query_id=query_id, page_num=3),
             call(query_id=query_id, page_num=4),
@@ -91,7 +111,8 @@ def test_sync_query_multiple_pages(mocker: MockerFixture) -> None:
 
     kwargs: QueryParameters = {"metrics": ["m1", "m2"], "group_by": ["gb"], "limit": 1}
 
-    result_table = client.query(**kwargs)
+    with client.session():
+        result_table = client.query(**kwargs)
 
     cq_mock.assert_called_once_with(**kwargs)
 


### PR DESCRIPTION
This commit refactors some of the internals of the GraphQL clients so that the `_poll_until_complete` method now accepts any kind of query job. This will make it more extensible for other kinds of queries such as exports.