### PR TITLE
Improve GraphQL API models

### DIFF
--- a/.changes/unreleased/Features-20240709-103228.yaml
+++ b/.changes/unreleased/Features-20240709-103228.yaml
@@ -1,0 +1,3 @@
+kind: Features
+body: Added `saved_query` fetching via GraphQL
+time: 2024-07-09T10:32:28.124763+02:00

--- a/.changes/unreleased/Features-20240709-103239.yaml
+++ b/.changes/unreleased/Features-20240709-103239.yaml
@@ -1,0 +1,3 @@
+kind: Features
+body: Added `entity` fetching via GraphQL
+time: 2024-07-09T10:32:39.659482+02:00

--- a/.changes/unreleased/Features-20240709-103250.yaml
+++ b/.changes/unreleased/Features-20240709-103250.yaml
@@ -1,0 +1,3 @@
+kind: Features
+body: Added more fields to `dimension`
+time: 2024-07-09T10:32:50.697778+02:00

--- a/.changes/unreleased/Features-20240709-103258.yaml
+++ b/.changes/unreleased/Features-20240709-103258.yaml
@@ -1,0 +1,3 @@
+kind: Features
+body: Added more fields to `metric`
+time: 2024-07-09T10:32:58.618167+02:00

--- a/.changes/unreleased/Under the Hood-20240709-103311.yaml
+++ b/.changes/unreleased/Under the Hood-20240709-103311.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Improved how GraphQL gets generated under the hood
+time: 2024-07-09T10:33:11.963657+02:00

--- a/dbtsl/api/graphql/client/asyncio.pyi
+++ b/dbtsl/api/graphql/client/asyncio.pyi
@@ -7,6 +7,7 @@ from typing_extensions import AsyncIterator, Unpack
 from dbtsl.api.shared.query_params import QueryParameters
 from dbtsl.models import (
     Dimension,
+    Entity,
     Measure,
     Metric,
 )
@@ -32,6 +33,10 @@ class AsyncGraphQLClient:
 
     async def measures(self, metrics: List[str]) -> List[Measure]:
         """Get a list of all available measures for a given metric."""
+        ...
+
+    async def entities(self, metrics: List[str]) -> List[Entity]:
+        """Get a list of all available entities for a given metric."""
         ...
 
     async def query(self, **params: Unpack[QueryParameters]) -> "pa.Table": ...

--- a/dbtsl/api/graphql/client/asyncio.pyi
+++ b/dbtsl/api/graphql/client/asyncio.pyi
@@ -10,6 +10,7 @@ from dbtsl.models import (
     Entity,
     Measure,
     Metric,
+    SavedQuery,
 )
 
 class AsyncGraphQLClient:
@@ -28,15 +29,19 @@ class AsyncGraphQLClient:
         ...
 
     async def dimensions(self, metrics: List[str]) -> List[Dimension]:
-        """Get a list of all available dimensions for a given metric."""
+        """Get a list of all available dimensions for a given set of metrics."""
         ...
 
     async def measures(self, metrics: List[str]) -> List[Measure]:
-        """Get a list of all available measures for a given metric."""
+        """Get a list of all available measures for a given set of metrics."""
         ...
 
     async def entities(self, metrics: List[str]) -> List[Entity]:
-        """Get a list of all available entities for a given metric."""
+        """Get a list of all available entities for a given set of metrics."""
+        ...
+
+    async def saved_queries(self) -> List[SavedQuery]:
+        """Get a list of all available saved queries."""
         ...
 
     async def query(self, **params: Unpack[QueryParameters]) -> "pa.Table": ...

--- a/dbtsl/api/graphql/client/sync.pyi
+++ b/dbtsl/api/graphql/client/sync.pyi
@@ -7,6 +7,7 @@ from typing_extensions import Self, Unpack
 from dbtsl.api.shared.query_params import QueryParameters
 from dbtsl.models import (
     Dimension,
+    Entity,
     Measure,
     Metric,
 )
@@ -32,6 +33,10 @@ class SyncGraphQLClient:
 
     def measures(self, metrics: List[str]) -> List[Measure]:
         """Get a list of all available measures for a given metric."""
+        ...
+
+    def entities(self, metrics: List[str]) -> List[Entity]:
+        """Get a list of all available entities for a given metric."""
         ...
 
     def query(self, **params: Unpack[QueryParameters]) -> "pa.Table": ...

--- a/dbtsl/api/graphql/client/sync.pyi
+++ b/dbtsl/api/graphql/client/sync.pyi
@@ -10,6 +10,7 @@ from dbtsl.models import (
     Entity,
     Measure,
     Metric,
+    SavedQuery,
 )
 
 class SyncGraphQLClient:
@@ -28,15 +29,19 @@ class SyncGraphQLClient:
         ...
 
     def dimensions(self, metrics: List[str]) -> List[Dimension]:
-        """Get a list of all available dimensions for a given metric."""
+        """Get a list of all available dimensions for a given set of metrics."""
         ...
 
     def measures(self, metrics: List[str]) -> List[Measure]:
-        """Get a list of all available measures for a given metric."""
+        """Get a list of all available measures for a given set of metrics."""
         ...
 
     def entities(self, metrics: List[str]) -> List[Entity]:
-        """Get a list of all available entities for a given metric."""
+        """Get a list of all available entities for a given set of metrics."""
+        ...
+
+    def saved_queries(self) -> List[SavedQuery]:
+        """Get a list of all available saved queries."""
         ...
 
     def query(self, **params: Unpack[QueryParameters]) -> "pa.Table": ...

--- a/dbtsl/api/graphql/protocol.py
+++ b/dbtsl/api/graphql/protocol.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Generic, List, Mapping, Protocol, TypedDict, TypeV
 from mashumaro.codecs.basic import decode as decode_to_dataclass
 from typing_extensions import NotRequired, override
 
+from dbtsl.api.graphql.util import render_query
 from dbtsl.api.shared.query_params import QueryParameters
 from dbtsl.models import Dimension, Measure, Metric
 from dbtsl.models.query import QueryId, QueryResult, QueryStatus
@@ -68,13 +69,11 @@ class ListMetricsOperation(ProtocolOperation[EmptyVariables, List[Metric]]):
         query = """
         query getMetrics($environmentId: BigInt!) {
             metrics(environmentId: $environmentId) {
-                name
-                description
-                type
+                ...&fragment
             }
         }
         """
-        return query
+        return render_query(query, Metric.gql_fragments())
 
     @override
     def get_request_variables(self, environment_id: int, **kwargs: EmptyVariables) -> Dict[str, Any]:
@@ -99,13 +98,11 @@ class ListDimensionsOperation(ProtocolOperation[ListEntitiesOperationVariables, 
         query = """
         query getDimensions($environmentId: BigInt!, $metrics: [MetricInput!]!) {
             dimensions(environmentId: $environmentId, metrics: $metrics) {
-                name
-                description
-                type
+                ...&fragment
             }
         }
         """
-        return query
+        return render_query(query, Dimension.gql_fragments())
 
     @override
     def get_request_variables(self, environment_id: int, **kwargs: ListEntitiesOperationVariables) -> Dict[str, Any]:
@@ -127,14 +124,11 @@ class ListMeasuresOperation(ProtocolOperation[ListEntitiesOperationVariables, Li
         query = """
         query getMeasures($environmentId: BigInt!, $metrics: [MetricInput!]!) {
             measures(environmentId: $environmentId, metrics: $metrics) {
-                name
-                aggTimeDimension
-                agg
-                expr
+                ...&fragment
             }
         }
         """
-        return query
+        return render_query(query, Measure.gql_fragments())
 
     @override
     def get_request_variables(self, environment_id: int, **kwargs: ListEntitiesOperationVariables) -> Dict[str, Any]:
@@ -203,16 +197,11 @@ class GetQueryResultOperation(ProtocolOperation[GetQueryResultVariables, QueryRe
             $pageNum: Int!
         ) {
             query(environmentId: $environmentId, queryId: $queryId, pageNum: $pageNum) {
-                queryId,
-                status,
-                sql,
-                error,
-                totalPages,
-                arrowResult
+                ...&fragment
             }
         }
         """
-        return query
+        return render_query(query, QueryResult.gql_fragments())
 
     @override
     def get_request_variables(self, environment_id: int, **kwargs: GetQueryResultVariables) -> Dict[str, Any]:

--- a/dbtsl/api/graphql/util.py
+++ b/dbtsl/api/graphql/util.py
@@ -1,0 +1,8 @@
+import re
+
+pat = re.compile(r"[ \t\n]+")
+
+
+def normalize_query(s: str) -> str:
+    """Return a normalized query string."""
+    return pat.subn(" ", s.strip("\n"))[0].strip()

--- a/dbtsl/api/graphql/util.py
+++ b/dbtsl/api/graphql/util.py
@@ -1,8 +1,40 @@
-import re
+from __future__ import annotations
 
-pat = re.compile(r"[ \t\n]+")
+import re
+from string import Template
+from typing import TYPE_CHECKING, List
+
+if TYPE_CHECKING:
+    from dbtsl.models.base import GraphQLFragment
+
+query_sub_pat = re.compile(r"[ \t\n]+")
 
 
 def normalize_query(s: str) -> str:
-    """Return a normalized query string."""
-    return pat.subn(" ", s.strip("\n"))[0].strip()
+    """Return a normalized query string.
+
+    This strips newlines, too many whitespaces etc so we can
+    make assertions that queries equal each other regarless of indentation.
+    """
+    return query_sub_pat.subn(" ", s.strip("\n"))[0].strip()
+
+
+class QueryTemplate(Template):
+    """Subclass Template since $ is reserved in GraphQL."""
+
+    delimiter = "&"
+
+
+def render_query(template_str: str, dependencies: List[GraphQLFragment]) -> str:
+    """Return a rendered query from a template and its fragment dependencies.
+
+    The template must have a &fragment which indicates where the main
+    fragment should be replaced in the query.
+
+    The main fragment will be dependencies[0].
+    """
+    template = QueryTemplate(template_str)
+    assert len(dependencies) > 0
+    template_render = normalize_query(template.substitute(fragment=dependencies[0].name))
+    segments = [template_render] + [normalize_query(frag.body) for frag in dependencies]
+    return " ".join(segments)

--- a/dbtsl/client/asyncio.pyi
+++ b/dbtsl/client/asyncio.pyi
@@ -5,7 +5,7 @@ import pyarrow as pa
 from typing_extensions import Self, Unpack
 
 from dbtsl.api.adbc.protocol import QueryParameters
-from dbtsl.models import Dimension, Measure, Metric
+from dbtsl.models import Dimension, Entity, Measure, Metric, SavedQuery
 
 class AsyncSemanticLayerClient:
     def __init__(
@@ -28,6 +28,14 @@ class AsyncSemanticLayerClient:
 
     async def measures(self, metrics: List[str]) -> List[Measure]:
         """List all the measures available for a given set of metrics."""
+        ...
+
+    async def entities(self, metrics: List[str]) -> List[Entity]:
+        """Get a list of all available entities for a given set of metrics."""
+        ...
+
+    async def saved_queries(self) -> List[SavedQuery]:
+        """Get a list of all available saved queries."""
         ...
 
     def session(self) -> AbstractAsyncContextManager[AsyncIterator[Self]]:

--- a/dbtsl/client/sync.pyi
+++ b/dbtsl/client/sync.pyi
@@ -5,7 +5,7 @@ import pyarrow as pa
 from typing_extensions import Self, Unpack
 
 from dbtsl.api.adbc.protocol import QueryParameters
-from dbtsl.models import Dimension, Measure, Metric
+from dbtsl.models import Dimension, Entity, Measure, Metric, SavedQuery
 
 class SyncSemanticLayerClient:
     def __init__(
@@ -28,6 +28,14 @@ class SyncSemanticLayerClient:
 
     def measures(self, metrics: List[str]) -> List[Measure]:
         """List all the measures available for a given set of metrics."""
+        ...
+
+    def entities(self, metrics: List[str]) -> List[Entity]:
+        """Get a list of all available entities for a given set of metrics."""
+        ...
+
+    async def saved_queries(self) -> List[SavedQuery]:
+        """Get a list of all available saved queries."""
         ...
 
     def session(self) -> AbstractContextManager[Iterator[Self]]:

--- a/dbtsl/models/__init__.py
+++ b/dbtsl/models/__init__.py
@@ -6,16 +6,19 @@ generated code from our GraphQL schema.
 
 from .base import BaseModel
 from .dimension import Dimension, DimensionType
+from .entity import Entity, EntityType
 from .measure import AggregationType, Measure
 from .metric import Metric, MetricType
 
 BaseModel._apply_aliases()
 
 __all__ = [
+    "AggregationType",
     "Dimension",
     "DimensionType",
+    "Entity",
+    "EntityType",
     "Measure",
-    "AggregationType",
     "Metric",
     "MetricType",
 ]

--- a/dbtsl/models/__init__.py
+++ b/dbtsl/models/__init__.py
@@ -9,6 +9,10 @@ from .dimension import Dimension, DimensionType
 from .entity import Entity, EntityType
 from .measure import AggregationType, Measure
 from .metric import Metric, MetricType
+from .query import QueryResult
+
+# Only importing this so it registers aliases
+_ = QueryResult
 
 BaseModel._apply_aliases()
 

--- a/dbtsl/models/__init__.py
+++ b/dbtsl/models/__init__.py
@@ -10,6 +10,7 @@ from .entity import Entity, EntityType
 from .measure import AggregationType, Measure
 from .metric import Metric, MetricType
 from .query import QueryResult
+from .time_granularity import TimeGranularity
 
 # Only importing this so it registers aliases
 _ = QueryResult
@@ -25,4 +26,5 @@ __all__ = [
     "Measure",
     "Metric",
     "MetricType",
+    "TimeGranularity",
 ]

--- a/dbtsl/models/__init__.py
+++ b/dbtsl/models/__init__.py
@@ -10,6 +10,7 @@ from .entity import Entity, EntityType
 from .measure import AggregationType, Measure
 from .metric import Metric, MetricType
 from .query import QueryResult
+from .saved_query import SavedQuery
 from .time_granularity import TimeGranularity
 
 # Only importing this so it registers aliases
@@ -26,5 +27,6 @@ __all__ = [
     "Measure",
     "Metric",
     "MetricType",
+    "SavedQuery",
     "TimeGranularity",
 ]

--- a/dbtsl/models/base.py
+++ b/dbtsl/models/base.py
@@ -49,13 +49,18 @@ class GraphQLFragment:
 
 
 class GraphQLFragmentMixin:
-    """Add this to any model that need to be fetched from GraphQL."""
+    """Add this to any model that needs to be fetched from GraphQL."""
 
     @classmethod
     def gql_model_name(cls) -> str:
         """The model's name in the GraphQL schema. Defaults to same as class name."""
         return cls.__name__
 
+    # NOTE: this will overflow the stack if we add any circular dependencies in our GraphQL schema, like
+    # Metric -> Dimension -> Metric -> Dimension ...
+    #
+    # If we do that, we need to modify this method to memoize what fragments were already created
+    # so that we exit the recursion gracefully
     @staticmethod
     def _get_fragments_for_field(type: Type, field_name: str) -> Union[str, List[GraphQLFragment]]:
         if inspect.isclass(type) and issubclass(type, GraphQLFragmentMixin):

--- a/dbtsl/models/base.py
+++ b/dbtsl/models/base.py
@@ -1,8 +1,16 @@
-from dataclasses import fields, is_dataclass
+import inspect
+from dataclasses import dataclass, fields, is_dataclass
+from dataclasses import field as dc_field
+from functools import cache
 from types import MappingProxyType
+from typing import List, Set, Type, Union
+from typing import get_args as get_type_args
+from typing import get_origin as get_type_origin
 
 from mashumaro import DataClassDictMixin, field_options
 from mashumaro.config import BaseConfig
+
+from dbtsl.api.graphql.util import normalize_query
 
 
 def snake_case_to_camel_case(s: str) -> str:
@@ -30,3 +38,66 @@ class BaseModel(DataClassDictMixin):
                 camel_name = snake_case_to_camel_case(field.name)
                 if field.name != camel_name:
                     field.metadata = MappingProxyType(field_options(alias=camel_name))
+
+
+@dataclass(frozen=True, eq=True)
+class GraphQLFragment:
+    """Represent a model as a GraphQL fragment."""
+
+    name: str
+    body: str = dc_field(hash=False)
+
+
+class GraphQLFragmentMixin:
+    """Add this to any model that need to be fetched from GraphQL."""
+
+    @classmethod
+    def gql_model_name(cls) -> str:
+        """The model's name in the GraphQL schema. Defaults to same as class name."""
+        return cls.__name__
+
+    @staticmethod
+    def _get_fragments_for_field(type: Type, field_name: str) -> Union[str, List[GraphQLFragment]]:
+        if inspect.isclass(type) and issubclass(type, GraphQLFragmentMixin):
+            return type.gql_fragments()
+
+        if get_type_origin(type) == list:
+            inner_type = get_type_args(type)[0]
+            return GraphQLFragmentMixin._get_fragments_for_field(inner_type, field_name)
+
+        return snake_case_to_camel_case(field_name)
+
+    @classmethod
+    @cache
+    def gql_fragments(cls) -> List[GraphQLFragment]:
+        """Get the GraphQL fragments needed to query for this model.
+
+        The first (0th) fragment is always the fragment that represents the model itself.
+        The remaining fragments are dependencies of the model, if any.
+        """
+        gql_model_name = cls.gql_model_name()
+        fragment_name = f"fragment{cls.__name__}"
+
+        assert is_dataclass(cls), "Subclass of GraphQLFragmentMixin must be dataclass"
+
+        query_elements: List[str] = []
+        dependencies: Set[GraphQLFragment] = set()
+        for field in fields(cls):
+            frag_or_field = GraphQLFragmentMixin._get_fragments_for_field(field.type, field.name)
+            if isinstance(frag_or_field, str):
+                query_elements.append(frag_or_field)
+            else:
+                frag = frag_or_field[0]
+                field_query = snake_case_to_camel_case(field.name) + " { ..." + frag.name + " }"
+                query_elements.append(field_query)
+                dependencies.update(frag_or_field)
+
+        query_str = "         \n".join(query_elements)
+
+        fragment_body = normalize_query(f"""
+        fragment {fragment_name} on {gql_model_name} {{
+            {query_str}
+        }}
+        """)
+        fragment = GraphQLFragment(name=fragment_name, body=fragment_body)
+        return [fragment] + list(dependencies)

--- a/dbtsl/models/dimension.py
+++ b/dbtsl/models/dimension.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from enum import Enum
 
-from dbtsl.models.base import BaseModel
+from dbtsl.models.base import BaseModel, GraphQLFragmentMixin
 
 
 class DimensionType(str, Enum):
@@ -12,7 +12,7 @@ class DimensionType(str, Enum):
 
 
 @dataclass(frozen=True)
-class Dimension(BaseModel):
+class Dimension(BaseModel, GraphQLFragmentMixin):
     """A metric dimension."""
 
     name: str

--- a/dbtsl/models/dimension.py
+++ b/dbtsl/models/dimension.py
@@ -1,7 +1,9 @@
 from dataclasses import dataclass
 from enum import Enum
+from typing import List, Optional
 
 from dbtsl.models.base import BaseModel, GraphQLFragmentMixin
+from dbtsl.models.time_granularity import TimeGranularity
 
 
 class DimensionType(str, Enum):
@@ -16,5 +18,10 @@ class Dimension(BaseModel, GraphQLFragmentMixin):
     """A metric dimension."""
 
     name: str
-    description: str
+    qualified_name: str
+    description: Optional[str]
     type: DimensionType
+    label: Optional[str]
+    is_partition: bool
+    expr: Optional[str]
+    queryable_granularities: List[TimeGranularity]

--- a/dbtsl/models/entity.py
+++ b/dbtsl/models/entity.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from dbtsl.models.base import BaseModel
+
+
+class EntityType(str, Enum):
+    """All supported entity types."""
+
+    FOREIGN = "FOREIGN"
+    NATURAL = "NATURAL"
+    PRIMARY = "PRIMARY"
+    UNIQUE = "UNIQUE"
+
+
+@dataclass(frozen=True)
+class Entity(BaseModel):
+    """An entity."""
+
+    name: str
+    description: Optional[str]
+    type: EntityType
+    role: str
+    expr: str

--- a/dbtsl/models/entity.py
+++ b/dbtsl/models/entity.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
-from dbtsl.models.base import BaseModel
+from dbtsl.models.base import BaseModel, GraphQLFragmentMixin
 
 
 class EntityType(str, Enum):
@@ -15,7 +15,7 @@ class EntityType(str, Enum):
 
 
 @dataclass(frozen=True)
-class Entity(BaseModel):
+class Entity(BaseModel, GraphQLFragmentMixin):
     """An entity."""
 
     name: str

--- a/dbtsl/models/measure.py
+++ b/dbtsl/models/measure.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
-from dbtsl.models.base import BaseModel
+from dbtsl.models.base import BaseModel, GraphQLFragmentMixin
 
 
 class AggregationType(str, Enum):
@@ -20,7 +20,7 @@ class AggregationType(str, Enum):
 
 
 @dataclass(frozen=True)
-class Measure(BaseModel):
+class Measure(BaseModel, GraphQLFragmentMixin):
     """A measure."""
 
     name: str

--- a/dbtsl/models/metric.py
+++ b/dbtsl/models/metric.py
@@ -1,7 +1,11 @@
 from dataclasses import dataclass
 from enum import Enum
+from typing import List, Optional
 
 from dbtsl.models.base import BaseModel
+from dbtsl.models.dimension import Dimension
+from dbtsl.models.entity import Entity
+from dbtsl.models.measure import Measure
 
 
 class MetricType(str, Enum):
@@ -12,16 +16,6 @@ class MetricType(str, Enum):
     CUMULATIVE = "CUMULATIVE"
     DERIVED = "DERIVED"
     CONVERSION = "CONVERSION"
-    UNKNOWN = "UNKNOWN"
-
-    @classmethod
-    def missing(cls, _: str) -> "MetricType":
-        """Return UNKNOWN by default.
-
-        Prevents client from breaking in case a new unknown type is introduced
-        by the server.
-        """
-        return cls.UNKNOWN
 
 
 @dataclass(frozen=True)
@@ -29,5 +23,8 @@ class Metric(BaseModel):
     """A metric."""
 
     name: str
-    description: str
+    description: Optional[str]
     type: MetricType
+    dimensions: List[Dimension]
+    measures: List[Measure]
+    entities: List[Entity]

--- a/dbtsl/models/metric.py
+++ b/dbtsl/models/metric.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional
 
-from dbtsl.models.base import BaseModel
+from dbtsl.models.base import BaseModel, GraphQLFragmentMixin
 from dbtsl.models.dimension import Dimension
 from dbtsl.models.entity import Entity
 from dbtsl.models.measure import Measure
@@ -19,7 +19,7 @@ class MetricType(str, Enum):
 
 
 @dataclass(frozen=True)
-class Metric(BaseModel):
+class Metric(BaseModel, GraphQLFragmentMixin):
     """A metric."""
 
     name: str

--- a/dbtsl/models/metric.py
+++ b/dbtsl/models/metric.py
@@ -6,6 +6,7 @@ from dbtsl.models.base import BaseModel, GraphQLFragmentMixin
 from dbtsl.models.dimension import Dimension
 from dbtsl.models.entity import Entity
 from dbtsl.models.measure import Measure
+from dbtsl.models.time_granularity import TimeGranularity
 
 
 class MetricType(str, Enum):
@@ -28,3 +29,6 @@ class Metric(BaseModel, GraphQLFragmentMixin):
     dimensions: List[Dimension]
     measures: List[Measure]
     entities: List[Entity]
+    queryable_granularities: List[TimeGranularity]
+    label: str
+    requires_metric_time: bool

--- a/dbtsl/models/query.py
+++ b/dbtsl/models/query.py
@@ -6,7 +6,7 @@ from typing import NewType, Optional
 
 import pyarrow as pa
 
-from dbtsl.models.base import BaseModel
+from dbtsl.models.base import BaseModel, GraphQLFragmentMixin
 
 QueryId = NewType("QueryId", str)
 
@@ -22,7 +22,7 @@ class QueryStatus(str, Enum):
 
 
 @dataclass(frozen=True)
-class QueryResult(BaseModel):
+class QueryResult(BaseModel, GraphQLFragmentMixin):
     """A query result containing its status, SQL and error/results."""
 
     query_id: QueryId

--- a/dbtsl/models/saved_query.py
+++ b/dbtsl/models/saved_query.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from dbtsl.models.base import BaseModel, GraphQLFragmentMixin
+
+
+@dataclass(frozen=True)
+class SavedQuery(BaseModel, GraphQLFragmentMixin):
+    """A saved query."""
+
+    name: str
+    description: Optional[str]
+    label: Optional[str]

--- a/dbtsl/models/time_granularity.py
+++ b/dbtsl/models/time_granularity.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+
+class TimeGranularity(str, Enum):
+    """A time granularity."""
+
+    NANOSECOND = "NANOSECOND"
+    MICROSECOND = "MICROSECOND"
+    MILLISECOND = "MILLISECOND"
+    SECOND = "SECOND"
+    MINUTE = "MINUTE"
+    HOUR = "HOUR"
+    DAY = "DAY"
+    WEEK = "WEEK"
+    MONTH = "MONTH"
+    QUARTER = "QUARTER"
+    YEAR = "YEAR"

--- a/examples/list_metrics_sync.py
+++ b/examples/list_metrics_sync.py
@@ -32,6 +32,21 @@ def main() -> None:
             print(f"     type={m.type}")
             print(f"     description={m.description}")
 
+            print("     dimensions=[")
+            for dim in m.dimensions:
+                print(f"        {dim.name},")
+            print("     ]")
+
+            print("     measures=[")
+            for measure in m.measures:
+                print(f"        {measure.name},")
+            print("     ]")
+
+            print("     entities=[")
+            for entity in m.entities:
+                print(f"        {entity.name},")
+            print("     ]")
+
 
 if __name__ == "__main__":
     main()

--- a/examples/list_saved_queries_async.py
+++ b/examples/list_saved_queries_async.py
@@ -1,0 +1,38 @@
+"""Fetch all available saved queries from the metadata API and display them."""
+
+import asyncio
+from argparse import ArgumentParser
+
+from dbtsl.asyncio import AsyncSemanticLayerClient
+
+
+def get_arg_parser() -> ArgumentParser:
+    p = ArgumentParser()
+
+    p.add_argument("--env-id", required=True, help="The dbt environment ID", type=int)
+    p.add_argument("--token", required=True, help="The API auth token")
+    p.add_argument("--host", required=True, help="The API host")
+
+    return p
+
+
+async def main() -> None:
+    arg_parser = get_arg_parser()
+    args = arg_parser.parse_args()
+
+    client = AsyncSemanticLayerClient(
+        environment_id=args.env_id,
+        auth_token=args.token,
+        host=args.host,
+    )
+
+    async with client.session():
+        saved_queries = await client.saved_queries()
+        for sq in saved_queries:
+            print(f"{sq.name}:")
+            print(f"  label: {sq.label}")
+            print(f"  description: {sq.description}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/api/graphql/test_util.py
+++ b/tests/api/graphql/test_util.py
@@ -1,4 +1,5 @@
-from dbtsl.api.graphql.util import normalize_query
+from dbtsl.api.graphql.util import normalize_query, render_query
+from dbtsl.models.base import GraphQLFragment
 
 
 def test_normalize_query() -> None:
@@ -12,3 +13,51 @@ def test_normalize_query() -> None:
     """
 
     assert normalize_query(q) == "myQuery { foo { baz bar } }"
+
+
+def test_render_query() -> None:
+    template = """
+    myQuery {
+        ...&fragment
+    }
+    """
+    dependencies = [
+        GraphQLFragment(
+            name="mainFrag",
+            body="""
+            fragment mainFrag on Test {
+                foo
+                bar
+                dep {
+                    ...depFrag
+                }
+            }
+            """,
+        ),
+        GraphQLFragment(
+            name="depFrag",
+            body="""
+            fragment depFrag on Dep {
+                baz
+            }
+            """,
+        ),
+    ]
+
+    expect = normalize_query("""
+    myQuery {
+        ...mainFrag
+    }
+    fragment mainFrag on Test {
+        foo
+        bar
+        dep {
+            ...depFrag
+        }
+    }
+    fragment depFrag on Dep {
+        baz
+    }
+    """)
+    rendered = render_query(template, dependencies)
+    assert normalize_query(expect) == rendered

--- a/tests/api/graphql/test_util.py
+++ b/tests/api/graphql/test_util.py
@@ -1,0 +1,14 @@
+from dbtsl.api.graphql.util import normalize_query
+
+
+def test_normalize_query() -> None:
+    q = """
+
+    myQuery {
+        foo {
+            baz
+        bar
+    } }
+    """
+
+    assert normalize_query(q) == "myQuery { foo { baz bar } }"

--- a/tests/integration/test_gql.py
+++ b/tests/integration/test_gql.py
@@ -30,7 +30,7 @@ def sync_client(credentials: Credentials) -> Iterator[SyncGraphQLClient]:
         yield client
 
 
-def test_sync_client_lists_metrics_and_dimensions(sync_client: SyncGraphQLClient) -> None:
+def test_sync_client_lists_metrics_dimensions_entities(sync_client: SyncGraphQLClient) -> None:
     metrics = sync_client.metrics()
     assert len(metrics) > 0
 
@@ -38,14 +38,22 @@ def test_sync_client_lists_metrics_and_dimensions(sync_client: SyncGraphQLClient
     assert len(dims) > 0
     assert dims == metrics[0].dimensions
 
+    entities = sync_client.entities(metrics=[metrics[0].name])
+    assert len(entities) > 0
+    assert entities == metrics[0].entities
 
-async def test_async_client_lists_metrics_and_dimensions(async_client: AsyncGraphQLClient) -> None:
+
+async def test_async_client_lists_metrics_dimensions_entities(async_client: AsyncGraphQLClient) -> None:
     metrics = await async_client.metrics()
     assert len(metrics) > 0
 
     dims = await async_client.dimensions(metrics=[metrics[0].name])
     assert len(dims) > 0
     assert dims == metrics[0].dimensions
+
+    entities = await async_client.entities(metrics=[metrics[0].name])
+    assert len(entities) > 0
+    assert entities == metrics[0].entities
 
 
 def test_sync_client_query_works(sync_client: SyncGraphQLClient) -> None:

--- a/tests/integration/test_gql.py
+++ b/tests/integration/test_gql.py
@@ -33,15 +33,19 @@ def sync_client(credentials: Credentials) -> Iterator[SyncGraphQLClient]:
 def test_sync_client_lists_metrics_and_dimensions(sync_client: SyncGraphQLClient) -> None:
     metrics = sync_client.metrics()
     assert len(metrics) > 0
+
     dims = sync_client.dimensions(metrics=[metrics[0].name])
     assert len(dims) > 0
+    assert dims == metrics[0].dimensions
 
 
 async def test_async_client_lists_metrics_and_dimensions(async_client: AsyncGraphQLClient) -> None:
     metrics = await async_client.metrics()
     assert len(metrics) > 0
+
     dims = await async_client.dimensions(metrics=[metrics[0].name])
     assert len(dims) > 0
+    assert dims == metrics[0].dimensions
 
 
 def test_sync_client_query_works(sync_client: SyncGraphQLClient) -> None:

--- a/tests/integration/test_gql.py
+++ b/tests/integration/test_gql.py
@@ -56,6 +56,16 @@ async def test_async_client_lists_metrics_dimensions_entities(async_client: Asyn
     assert entities == metrics[0].entities
 
 
+def test_sync_client_lists_saved_queries(sync_client: SyncGraphQLClient) -> None:
+    sqs = sync_client.saved_queries()
+    assert len(sqs) > 0
+
+
+async def test_async_client_lists_saved_queries(async_client: AsyncGraphQLClient) -> None:
+    sqs = await async_client.saved_queries()
+    assert len(sqs) > 0
+
+
 def test_sync_client_query_works(sync_client: SyncGraphQLClient) -> None:
     metrics = sync_client.metrics()
     assert len(metrics) > 0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass
+from typing import List
 
 from mashumaro.codecs.basic import decode
 
-from dbtsl.models.base import BaseModel
+from dbtsl.api.graphql.util import normalize_query
+from dbtsl.models.base import BaseModel, GraphQLFragmentMixin
 from dbtsl.models.base import snake_case_to_camel_case as stc
 
 
@@ -30,3 +32,48 @@ def test_base_model_auto_alias() -> None:
 
     codec_model = decode(data, SubModel)
     assert codec_model.hello_world == "asdf"
+
+
+def test_graphql_fragment_mixin() -> None:
+    @dataclass
+    class A(BaseModel, GraphQLFragmentMixin):
+        foo_bar: str
+
+    @dataclass
+    class B(BaseModel, GraphQLFragmentMixin):
+        hello_world: str
+        baz: str
+        a: A
+        many_a: List[A]
+
+    a_fragments = A.gql_fragments()
+    assert len(a_fragments) == 1
+    a_fragment = a_fragments[0]
+
+    a_expect = normalize_query("""
+    fragment fragmentA on A {
+        fooBar
+    }
+    """)
+    assert a_fragment.name == "fragmentA"
+    assert a_fragment.body == a_expect
+
+    b_fragments = B.gql_fragments()
+    assert len(b_fragments) == 2
+    b_fragment = b_fragments[0]
+
+    b_expect = normalize_query("""
+    fragment fragmentB on B {
+        helloWorld
+        baz
+        a {
+            ...fragmentA
+        }
+        manyA {
+            ...fragmentA
+        }
+    }
+    """)
+    assert b_fragment.name == "fragmentB"
+    assert b_fragment.body == b_expect
+    assert b_fragments[1] == a_fragment


### PR DESCRIPTION
This commit improves the models that can be fetched via the GraphQL API.

Added models:
- Saved Query
- Entity

Improved models:
- Dimension
- Metric

It also improves our GraphQL generation logic so that models will automatically generate their queries based on the dataclass fields.