### PR TITLE
chore: add `stage_fixed` to lefthook

### DIFF
--- a/.changes/unreleased/Chore-20240709-115016.yaml
+++ b/.changes/unreleased/Chore-20240709-115016.yaml
@@ -1,0 +1,3 @@
+kind: Chore
+body: Add `stage_fix` to lefthook hooks
+time: 2024-07-09T11:50:16.68638+02:00

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -2,8 +2,10 @@ pre-commit:
   commands:
     ruff-format:
       run: "hatch run dev:ruff format"
+      stage_fixed: true
     ruff-lint:
       run: "hatch run dev:ruff check --fix"
+      stage_fixed: true
     pyright:
       run: "hatch run dev:basedpyright"
 


### PR DESCRIPTION
Lefthook was leaving files behind whenever there was any formatting or linting changes. This should fix it.