### PR TITLE
feat: full query parameters

### DIFF
--- a/.changes/unreleased/Features-20240709-121955.yaml
+++ b/.changes/unreleased/Features-20240709-121955.yaml
@@ -1,0 +1,3 @@
+kind: Features
+body: Full support for all query parameters
+time: 2024-07-09T12:19:55.649315+02:00

--- a/dbtsl/api/adbc/protocol.py
+++ b/dbtsl/api/adbc/protocol.py
@@ -13,7 +13,11 @@ class ADBCProtocol:
         def append_param_if_exists(p_str: str, p_name: str) -> str:
             p_value = params.get(p_name)
             if p_value is not None:
-                p_str += f"{p_name}={json.dumps(p_value)},"
+                if isinstance(p_value, bool):
+                    dumped = str(p_value)
+                else:
+                    dumped = json.dumps(p_value)
+                p_str += f"{p_name}={dumped},"
             return p_str
 
         serialized_params = append_param_if_exists(serialized_params, "metrics")
@@ -21,6 +25,7 @@ class ADBCProtocol:
         serialized_params = append_param_if_exists(serialized_params, "limit")
         serialized_params = append_param_if_exists(serialized_params, "order_by")
         serialized_params = append_param_if_exists(serialized_params, "where")
+        serialized_params = append_param_if_exists(serialized_params, "read_cache")
 
         serialized_params = serialized_params.strip(",")
 

--- a/dbtsl/api/graphql/protocol.py
+++ b/dbtsl/api/graphql/protocol.py
@@ -200,11 +200,21 @@ class CreateQueryOperation(ProtocolOperation[QueryParameters, QueryId]):
         query = """
         mutation createQuery(
             $environmentId: BigInt!,
-            $metrics: [MetricInput!]!
+            $metrics: [MetricInput!]!,
+            $groupBy: [GroupByInput!]!,
+            $where: [WhereInput!]!,
+            $orderBy: [OrderByInput!]!,
+            $limit: Int,
+            $readCache: Boolean,
         ) {
             createQuery(
                 environmentId: $environmentId,
-                metrics: $metrics
+                metrics: $metrics,
+                groupBy: $groupBy,
+                where: $where,
+                orderBy: $orderBy,
+                limit: $limit,
+                readCache: $readCache,
             ) {
                 queryId
             }
@@ -221,6 +231,7 @@ class CreateQueryOperation(ProtocolOperation[QueryParameters, QueryId]):
             "where": [{"sql": sql} for sql in kwargs.get("where", [])],
             "orderBy": [{"name": o} for o in kwargs.get("order_by", [])],
             "limit": kwargs.get("limit", None),
+            "readCache": kwargs.get("read_cache", True),
         }
 
     @override

--- a/dbtsl/api/shared/query_params.py
+++ b/dbtsl/api/shared/query_params.py
@@ -18,3 +18,4 @@ class QueryParameters(TypedDict):
     limit: NotRequired[int]
     order_by: NotRequired[List[str]]
     where: NotRequired[List[str]]
+    read_cache: NotRequired[bool]

--- a/tests/api/adbc/test_protocol.py
+++ b/tests/api/adbc/test_protocol.py
@@ -16,12 +16,14 @@ def test_serialize_query_params_complete_query() -> None:
             "limit": 1,
             "order_by": ["dim_c"],
             "where": ['{{ Dimension("metric_time").grain("month") }} >= \'2017-03-09\''],
+            "read_cache": False,
         }
     )
 
     expected = (
         'metrics=["a", "b"],group_by=["dim_c"],limit=1,order_by=["dim_c"],'
-        'where=["{{ Dimension(\\"metric_time\\").grain(\\"month\\") }} >= \'2017-03-09\'"]'
+        'where=["{{ Dimension(\\"metric_time\\").grain(\\"month\\") }} >= \'2017-03-09\'"],'
+        "read_cache=False"
     )
     assert params == expected
 


### PR DESCRIPTION
This commit adds all supported params to our `query` methods in both GraphQL and ADBC.

Before, we were just using the `metrics` filter.