### PR TITLE
deps: lower minimum `pyarrow` version

### DIFF
--- a/.changes/unreleased/Dependencies-20240819-132546.yaml
+++ b/.changes/unreleased/Dependencies-20240819-132546.yaml
@@ -1,0 +1,3 @@
+kind: Dependencies
+body: Lower minimum PyArrow version to `12.0.0`
+time: 2024-08-19T13:25:46.2092+02:00

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "mashumaro>=3.11,<4.0",
   "typing-extensions>=4.4.0,<5.0.0; python_version<='3.11'",
   "typing-extensions>=4.7.0,<5.0.0; python_version>= '3.12'",
-  "pyarrow>=13.0.0; python_version<='3.11'",
+  "pyarrow>=12.0.0; python_version<='3.11'",
   "pyarrow>=14.0.0; python_version>='3.12'",
   "adbc-driver-flightsql>=0.11.0",
   "adbc-driver-manager>=0.11.0",


### PR DESCRIPTION
This commit lowers the minimum supported pyarrow version. We can do that with no code changes and the SDK still works and all [unit and integration tests pass](https://github.com/dbt-labs/semantic-layer-sdk-python/actions/runs/10452463632/job/28940925527?pr=40).