### PR TITLE
refactor: make error strings better

### DIFF
--- a/.changes/unreleased/Under the Hood-20240906-184939.yaml
+++ b/.changes/unreleased/Under the Hood-20240906-184939.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Better error messages
+time: 2024-09-06T18:49:39.208985+02:00

--- a/dbtsl/backoff.py
+++ b/dbtsl/backoff.py
@@ -29,6 +29,6 @@ class ExponentialBackoff:
             curr_ms = int(time.time() * 1000)
             elapsed_ms = curr_ms - start_ms
             if elapsed_ms > self.timeout_ms:
-                raise TimeoutError()
+                raise TimeoutError(timeout_ms=self.timeout_ms)
 
             yield min(int(self.base_interval_ms * self.exp_factor**i), self.max_interval_ms)

--- a/dbtsl/error.py
+++ b/dbtsl/error.py
@@ -1,9 +1,30 @@
 class SemanticLayerError(RuntimeError):
     """Any errors related to the Semantic Layer inherit from this."""
 
+    def __str__(self) -> str:
+        """RuntimeError doesn't stringify itself by default, so we need to manually add this."""
+        return self.__class__.__name__
+
+    def __repr__(self) -> str:
+        """RuntimeError doesn't stringify itself by default, so we need to manually add this."""
+        return str(self)
+
 
 class TimeoutError(SemanticLayerError):
     """Raise whenever a request times out."""
+
+    def __init__(self, *args, timeout_ms: int, **kwargs) -> None:
+        """Initialize the timeout error.
+
+        Args:
+            timeout_ms: The maximum time limit that got exceeded, in milliseconds
+            *args: any other exception args
+            **kwargs: any other exception kwargs
+        """
+        self.timeout_ms = timeout_ms
+
+    def __str__(self) -> str:  # noqa: D105
+        return f"{self.__class__.__name__}(timeout_ms={self.timeout_ms})"
 
 
 class QueryFailedError(SemanticLayerError):

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -1,0 +1,13 @@
+from dbtsl.error import SemanticLayerError, TimeoutError
+
+
+def test_error_str() -> None:
+    assert str(SemanticLayerError()) == "SemanticLayerError"
+
+
+def test_error_repr() -> None:
+    assert repr(SemanticLayerError()) == "SemanticLayerError"
+
+
+def test_timeout_error_str() -> None:
+    assert str(TimeoutError(timeout_ms=1000)) == "TimeoutError(timeout_ms=1000)"


### PR DESCRIPTION
This commit makes our error messages better since our errors weren't stringifying properly. It also adds a `timeout_ms` parameter to the `TimeoutError` so users get a proper feedback of what the current timeout is set at.