### PR TITLE
fix: wrong type annotation in for `saved_queries`

### DIFF
--- a/.changes/unreleased/Fixes-20240920-202558.yaml
+++ b/.changes/unreleased/Fixes-20240920-202558.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Fixed wrong annotation for `saved_queries` in sync client.
+time: 2024-09-20T20:25:58.362587+02:00

--- a/dbtsl/client/sync.pyi
+++ b/dbtsl/client/sync.pyi
@@ -42,7 +42,7 @@ class SyncSemanticLayerClient:
         """Get a list of all available entities for a given set of metrics."""
         ...
 
-    async def saved_queries(self) -> List[SavedQuery]:
+    def saved_queries(self) -> List[SavedQuery]:
         """Get a list of all available saved queries."""
         ...
 

--- a/tests/integration/test_sl_client.py
+++ b/tests/integration/test_sl_client.py
@@ -72,10 +72,9 @@ async def test_client_works_multiple(subtests: SubTests, client: BothClients) ->
         dim_values = await maybe_await(client.dimension_values(metrics=[metric.name], group_by=dimension.name))
         assert len(dim_values) > 0
 
-
-async def test_client_lists_saved_queries(client: BothClients) -> None:
-    sqs = await maybe_await(client.saved_queries())
-    assert len(sqs) > 0
+    with subtests.test("saved_queries"):
+        sqs = await maybe_await(client.saved_queries())
+        assert len(sqs) > 0
 
 
 @pytest.mark.parametrize("api", [ADBC, GRAPHQL])


### PR DESCRIPTION
The sync client had an `async` method in its type annotations, which probably got there by my fast copy pasting. This commit fixes that.