### PR TITLE
feat: support for custom time granularities

### DIFF
--- a/.changes/unreleased/Breaking Changes-20241017-144053.yaml
+++ b/.changes/unreleased/Breaking Changes-20241017-144053.yaml
@@ -1,0 +1,3 @@
+kind: Breaking Changes
+body: '`Dimension` and `Metric`''s `queryable_granularities` can now contain strings that correspond to custom grains. Elements can still be `TimeGranularity`, though'
+time: 2024-10-17T14:40:53.023434+02:00

--- a/.changes/unreleased/Features-20241017-143959.yaml
+++ b/.changes/unreleased/Features-20241017-143959.yaml
@@ -1,0 +1,3 @@
+kind: Features
+body: Add support for custom time granularities
+time: 2024-10-17T14:39:59.367812+02:00

--- a/dbtsl/api/adbc/protocol.py
+++ b/dbtsl/api/adbc/protocol.py
@@ -9,6 +9,7 @@ from dbtsl.api.shared.query_params import (
     QueryParameters,
     validate_query_parameters,
 )
+from dbtsl.models.time import TimeGranularity
 
 
 class ADBCProtocol:
@@ -32,7 +33,7 @@ class ADBCProtocol:
         if isinstance(val, OrderByGroupBy):
             d = f'Dimension("{val.name}")'
             if val.grain:
-                grain_str = val.grain.name.lower()
+                grain_str = val.grain.name.lower() if isinstance(val.grain, TimeGranularity) else val.grain.lower()
                 d += f'.grain("{grain_str}")'
             if val.descending:
                 d += ".descending(True)"

--- a/dbtsl/api/shared/query_params.py
+++ b/dbtsl/api/shared/query_params.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import List, Optional, TypedDict, Union
 
-from dbtsl.models.time import TimeGranularity
+from dbtsl.models.time import Grain
 
 
 @dataclass(frozen=True)
@@ -20,7 +20,7 @@ class OrderByGroupBy:
     """
 
     name: str
-    grain: Optional[TimeGranularity]
+    grain: Optional[Grain]
     descending: bool = False
 
 

--- a/dbtsl/models/__init__.py
+++ b/dbtsl/models/__init__.py
@@ -20,7 +20,7 @@ from .saved_query import (
     SavedQueryQueryParams,
     SavedQueryWhereParam,
 )
-from .time import DatePart, TimeGranularity
+from .time import DatePart, Grain, TimeGranularity
 
 # Only importing this so it registers aliases
 _ = QueryResult
@@ -37,6 +37,7 @@ __all__ = [
     "Export",
     "ExportConfig",
     "ExportDestinationType",
+    "Grain",
     "Measure",
     "Metric",
     "MetricType",

--- a/dbtsl/models/dimension.py
+++ b/dbtsl/models/dimension.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import List, Optional
 
 from dbtsl.models.base import BaseModel, GraphQLFragmentMixin
-from dbtsl.models.time import TimeGranularity
+from dbtsl.models.time import Grain
 
 
 class DimensionType(str, Enum):
@@ -24,4 +24,4 @@ class Dimension(BaseModel, GraphQLFragmentMixin):
     label: Optional[str]
     is_partition: bool
     expr: Optional[str]
-    queryable_granularities: List[TimeGranularity]
+    queryable_granularities: List[Grain]

--- a/dbtsl/models/dimension.py
+++ b/dbtsl/models/dimension.py
@@ -1,6 +1,8 @@
-from dataclasses import dataclass
+from dataclasses import InitVar, dataclass
 from enum import Enum
 from typing import List, Optional
+
+from typing_extensions import override
 
 from dbtsl.models.base import BaseModel, GraphQLFragmentMixin
 from dbtsl.models.time import Grain
@@ -25,3 +27,24 @@ class Dimension(BaseModel, GraphQLFragmentMixin):
     is_partition: bool
     expr: Optional[str]
     queryable_granularities: List[Grain]
+
+    queryable_time_granilarities: InitVar[List[str]]
+
+    @override
+    @classmethod
+    def extra_gql_fields(cls) -> List[str]:
+        return ["queryableTimeGranularities"]
+
+    def __post_init__(self, queryable_time_granilarities: List[str]) -> None:
+        """Initialize queryable_granularities from queryable_time_granilarities.
+
+        In GraphQL, the standard time granularities are in `queryableGranularities`
+        but the custom time granularities are in `queryableTimeGranularities`.
+
+        Here' we're setting `queryable_time_granilarities` as an `InitVar`, and
+        making `queryable_granularities` contain both standard and non standard
+        `Grain`s.
+
+        This method is what merges both of them.
+        """
+        self.queryable_granularities.extend(queryable_time_granilarities)

--- a/dbtsl/models/metric.py
+++ b/dbtsl/models/metric.py
@@ -1,6 +1,8 @@
-from dataclasses import dataclass
+from dataclasses import InitVar, dataclass
 from enum import Enum
 from typing import List, Optional
+
+from typing_extensions import override
 
 from dbtsl.models.base import BaseModel, GraphQLFragmentMixin
 from dbtsl.models.dimension import Dimension
@@ -32,3 +34,24 @@ class Metric(BaseModel, GraphQLFragmentMixin):
     queryable_granularities: List[Grain]
     label: str
     requires_metric_time: bool
+
+    queryable_time_granilarities: InitVar[List[str]]
+
+    @override
+    @classmethod
+    def extra_gql_fields(cls) -> List[str]:
+        return ["queryableTimeGranularities"]
+
+    def __post_init__(self, queryable_time_granilarities: List[str]) -> None:
+        """Initialize queryable_granularities from queryable_time_granilarities.
+
+        In GraphQL, the standard time granularities are in `queryableGranularities`
+        but the custom time granularities are in `queryableTimeGranularities`.
+
+        Here' we're setting `queryable_time_granilarities` as an `InitVar`, and
+        making `queryable_granularities` contain both standard and non standard
+        `Grain`s.
+
+        This method is what merges both of them.
+        """
+        self.queryable_granularities.extend(queryable_time_granilarities)

--- a/dbtsl/models/metric.py
+++ b/dbtsl/models/metric.py
@@ -6,7 +6,7 @@ from dbtsl.models.base import BaseModel, GraphQLFragmentMixin
 from dbtsl.models.dimension import Dimension
 from dbtsl.models.entity import Entity
 from dbtsl.models.measure import Measure
-from dbtsl.models.time import TimeGranularity
+from dbtsl.models.time import Grain
 
 
 class MetricType(str, Enum):
@@ -29,6 +29,6 @@ class Metric(BaseModel, GraphQLFragmentMixin):
     dimensions: List[Dimension]
     measures: List[Measure]
     entities: List[Entity]
-    queryable_granularities: List[TimeGranularity]
+    queryable_granularities: List[Grain]
     label: str
     requires_metric_time: bool

--- a/dbtsl/models/saved_query.py
+++ b/dbtsl/models/saved_query.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import List, Optional
 
 from dbtsl.models.base import BaseModel, GraphQLFragmentMixin
-from dbtsl.models.time import DatePart, TimeGranularity
+from dbtsl.models.time import DatePart, Grain
 
 
 class ExportDestinationType(str, Enum):
@@ -42,7 +42,7 @@ class SavedQueryGroupByParam(BaseModel, GraphQLFragmentMixin):
     """The groupBy param of a saved query."""
 
     name: str
-    grain: Optional[TimeGranularity]
+    grain: Optional[Grain]
     date_part: Optional[DatePart]
 
 

--- a/dbtsl/models/time.py
+++ b/dbtsl/models/time.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Union
 
 
 class TimeGranularity(str, Enum):
@@ -15,6 +16,10 @@ class TimeGranularity(str, Enum):
     MONTH = "MONTH"
     QUARTER = "QUARTER"
     YEAR = "YEAR"
+
+
+Grain = Union[TimeGranularity, str]
+"""Either a standard TimeGranularity or a custom grain."""
 
 
 class DatePart(str, Enum):

--- a/tests/api/adbc/test_protocol.py
+++ b/tests/api/adbc/test_protocol.py
@@ -30,6 +30,10 @@ def test_serialize_val_OrderByGroupBy() -> None:
         ADBCProtocol._serialize_val(OrderByGroupBy(name="m", grain=TimeGranularity.WEEK, descending=True))
         == 'Dimension("m").grain("week").descending(True)'
     )
+    assert (
+        ADBCProtocol._serialize_val(OrderByGroupBy(name="m", grain="custom_grain"))
+        == 'Dimension("m").grain("custom_grain")'
+    )
 
 
 def test_serialize_query_params_metrics() -> None:


### PR DESCRIPTION
## Summary
This PR adds support for custom time granularities in the SDK.

## Changes
- Introduced new `Grain` type that can be either the standard `TimeGranularity` or `str`, representing a custom grain.
- Changed all references to `TimeGranularity` in our input/output models to use `Grain`
- Introduced some logic to query for the extra GraphQL field and merge it to `queryable_granularities` at `__post_init__` in `Metric` and `Dimension`.

I recommend reviewing this commit by commit.

## Breaking changes
Users expecting `Metric.queryable_granularities` and `Dimension.queryable_granularities` to be only `TimeGranularity` now need to account for them being `str`.