### PR TITLE
fix: serialization issues in GraphQL `orderBy` and `where`

### DIFF
--- a/.changes/unreleased/Fixes-20241111-182559.yaml
+++ b/.changes/unreleased/Fixes-20241111-182559.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Fixes issue with `orderBy` and `where` when going via GraphQL
+time: 2024-11-11T18:25:59.874757+01:00

--- a/dbtsl/api/graphql/protocol.py
+++ b/dbtsl/api/graphql/protocol.py
@@ -207,7 +207,7 @@ def get_query_request_variables(environment_id: int, params: QueryParameters) ->
         "orderBy": [
             {"metric": {"name": clause.name}, "descending": clause.descending}
             if isinstance(clause, OrderByMetric)
-            else {"groupBy": {"name": clause.name, "grain": clause.grain}, "descending": clause.descending}
+            else {"groupBy": {"name": clause.name, "timeGranularity": clause.grain}, "descending": clause.descending}
             for clause in strict_params.order_by
         ]
         if strict_params.order_by is not None
@@ -244,8 +244,8 @@ class CreateQueryOperation(ProtocolOperation[QueryParameters, QueryId]):
             $savedQuery: String,
             $metrics: [MetricInput!],
             $groupBy: [GroupByInput!],
-            $where: [WhereInput!]!,
-            $orderBy: [OrderByInput!]!,
+            $where: [WhereInput!],
+            $orderBy: [OrderByInput!],
             $limit: Int,
             $readCache: Boolean,
         ) {
@@ -324,8 +324,8 @@ class CompileSqlOperation(ProtocolOperation[QueryParameters, str]):
             $savedQuery: String,
             $metrics: [MetricInput!],
             $groupBy: [GroupByInput!],
-            $where: [WhereInput!]!,
-            $orderBy: [OrderByInput!]!,
+            $where: [WhereInput!],
+            $orderBy: [OrderByInput!],
             $limit: Int,
             $readCache: Boolean,
         ) {

--- a/tests/api/graphql/test_protocol.py
+++ b/tests/api/graphql/test_protocol.py
@@ -1,22 +1,52 @@
-from pytest_subtests import SubTests
+from typing import Any, Dict, List, Tuple
+
+import pytest
 
 from dbtsl.api.graphql.protocol import GraphQLProtocol
 
 from ...conftest import QueryValidator
+from ...query_test_cases import TEST_QUERIES
+
+VARIABLES = {
+    "metrics": [{}],
+    "dimensions": [{"metrics": ["m"]}],
+    "measures": [{"metrics": ["m"]}],
+    "entities": [{"metrics": ["m"]}],
+    "saved_queries": [{}],
+    "get_query_result": [{"query_id": 1}],
+    "create_query": TEST_QUERIES,
+    "compile_sql": TEST_QUERIES,
+}
+
+TestCase = Tuple[str, Dict[str, Any]]
+TEST_CASES: List[TestCase] = []
+
+for op_name in dir(GraphQLProtocol):
+    if op_name.startswith("__"):
+        continue
+
+    tested_vars = VARIABLES.get(op_name)
+    assert tested_vars is not None, f"No test vars to use for testing GraphQLProtocol.{op_name}"
+
+    for variables in tested_vars:
+        TEST_CASES.append((op_name, variables))
 
 
-def test_queries_are_valid(subtests: SubTests, validate_query: QueryValidator) -> None:
+def get_test_id(test_case: TestCase) -> str:
+    return test_case[0]
+
+
+@pytest.mark.parametrize("test_case", TEST_CASES, ids=get_test_id)
+def test_queries_are_valid(test_case: TestCase, validate_query: QueryValidator) -> None:
     """Test all GraphQL queries in `GraphQLProtocol` are valid against the server schema.
 
     This test dynamically iterates over `GraphQLProtocol` so whenever a new method is
-    added it will get tested automatically.
+    added it will get tested automatically. The test will fail if there's no entry in VARIABLES
+    for it.
     """
-    prop_names = dir(GraphQLProtocol)
-    for prop_name in prop_names:
-        if prop_name.startswith("__"):
-            continue
+    op_name, raw_variables = test_case
 
-        prop_val = getattr(GraphQLProtocol, prop_name)
-        with subtests.test(msg=f"GraphQLProtocol.{prop_name}"):
-            query = prop_val.get_request_text()
-            validate_query(query)
+    op = getattr(GraphQLProtocol, op_name)
+    query = op.get_request_text()
+    variable_values = op.get_request_variables(environment_id=123, **raw_variables)
+    validate_query(query, variable_values)

--- a/tests/query_test_cases.py
+++ b/tests/query_test_cases.py
@@ -17,6 +17,11 @@ TEST_QUERIES: List[QueryParameters] = [
     {
         "metrics": ["order_total"],
     },
+    # ad hoc query, metric and group by
+    {
+        "metrics": ["order_total"],
+        "group_by": ["customer__customer_type"],
+    },
     # saved query, all parameters
     {
         "saved_query": "order_metrics",

--- a/tests/query_test_cases.py
+++ b/tests/query_test_cases.py
@@ -1,0 +1,32 @@
+from typing import List
+
+from dbtsl import OrderByGroupBy
+from dbtsl.api.shared.query_params import QueryParameters
+
+TEST_QUERIES: List[QueryParameters] = [
+    # ad hoc query, all parameters
+    {
+        "metrics": ["order_total"],
+        "group_by": ["customer__customer_type"],
+        "order_by": ["customer__customer_type"],
+        "where": ["1=1"],
+        "limit": 1,
+        "read_cache": True,
+    },
+    # ad hoc query, only metric
+    {
+        "metrics": ["order_total"],
+    },
+    # saved query, all parameters
+    {
+        "saved_query": "order_metrics",
+        "order_by": [OrderByGroupBy(name="metric_time", grain="day")],
+        "where": ["1=1"],
+        "limit": 1,
+        "read_cache": True,
+    },
+    # saved query, no parameters
+    {
+        "saved_query": "order_metrics",
+    },
+]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -223,6 +223,15 @@ def test_validate_query_params_adhoc_query_no_metrics() -> None:
         validate_query_parameters(p)
 
 
+def test_validate_query_params_saved_query_group_by() -> None:
+    p: QueryParameters = {
+        "saved_query": "sq",
+        "group_by": ["a", "b"],
+    }
+    with pytest.raises(ValueError):
+        validate_query_parameters(p)
+
+
 def test_validate_query_params_adhoc_and_saved_query() -> None:
     p: QueryParameters = {"metrics": ["a", "b"], "group_by": ["a", "b"], "saved_query": "a"}
     with pytest.raises(ValueError):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -239,6 +239,6 @@ def test_validate_query_params_adhoc_and_saved_query() -> None:
 
 
 def test_validate_query_params_no_query() -> None:
-    p: QueryParameters = {"limit": 1, "where": ["1=1"], "order_by": ["a"], "read_cache": False}
+    p: QueryParameters = {"group_by": ["gb"], "limit": 1, "where": ["1=1"], "order_by": ["a"], "read_cache": False}
     with pytest.raises(ValueError):
         validate_query_parameters(p)


### PR DESCRIPTION
This commit fixes some serialization issues that were showing up with `orderBy` and `where` for the GraphQL protocol. This was affecting `compile_sql()` mainly since queries go via ADBC.

To avoid regressions, I added checks for variable values in the GraphQL tests. It will try to serialize those variable values and bind them to the query using `graphql` utilities. If the query is not valid, i.e the query + variables do not respect the server schema, it will fail. This requires no connection to the server other than fetching the schema.

I also added integration tests that will connect to the server. This will only run after unit test, though, so these issues should be caught before integration tests.