### PR TITLE
feat: add support for groupby-only adhoc queries

### DIFF
--- a/.changes/unreleased/Features-20241112-154335.yaml
+++ b/.changes/unreleased/Features-20241112-154335.yaml
@@ -1,0 +1,3 @@
+kind: Features
+body: Support for adhoc queries with only groupby. This is equivalent to listing dimension values.
+time: 2024-11-12T15:43:35.746064+01:00

--- a/dbtsl/api/graphql/client/asyncio.pyi
+++ b/dbtsl/api/graphql/client/asyncio.pyi
@@ -57,6 +57,15 @@ class AsyncGraphQLClient:
     @overload
     async def compile_sql(
         self,
+        group_by: List[str],
+        limit: Optional[int] = None,
+        order_by: Optional[List[Union[str, OrderByGroupBy]]] = None,
+        where: Optional[List[str]] = None,
+        read_cache: bool = True,
+    ) -> str: ...
+    @overload
+    async def compile_sql(
+        self,
         saved_query: str,
         limit: Optional[int] = None,
         order_by: Optional[List[Union[OrderByGroupBy, OrderByMetric]]] = None,
@@ -74,6 +83,15 @@ class AsyncGraphQLClient:
         group_by: Optional[List[str]] = None,
         limit: Optional[int] = None,
         order_by: Optional[List[Union[str, OrderByGroupBy, OrderByMetric]]] = None,
+        where: Optional[List[str]] = None,
+        read_cache: bool = True,
+    ) -> "pa.Table": ...
+    @overload
+    async def query(
+        self,
+        group_by: List[str],
+        limit: Optional[int] = None,
+        order_by: Optional[List[Union[str, OrderByGroupBy]]] = None,
         where: Optional[List[str]] = None,
         read_cache: bool = True,
     ) -> "pa.Table": ...

--- a/dbtsl/api/graphql/client/sync.pyi
+++ b/dbtsl/api/graphql/client/sync.pyi
@@ -57,6 +57,15 @@ class SyncGraphQLClient:
     @overload
     def compile_sql(
         self,
+        group_by: List[str],
+        limit: Optional[int] = None,
+        order_by: Optional[List[Union[str, OrderByGroupBy]]] = None,
+        where: Optional[List[str]] = None,
+        read_cache: bool = True,
+    ) -> str: ...
+    @overload
+    def compile_sql(
+        self,
         saved_query: str,
         limit: Optional[int] = None,
         order_by: Optional[List[Union[OrderByGroupBy, OrderByMetric]]] = None,
@@ -74,6 +83,15 @@ class SyncGraphQLClient:
         group_by: Optional[List[str]] = None,
         limit: Optional[int] = None,
         order_by: Optional[List[Union[str, OrderByGroupBy, OrderByMetric]]] = None,
+        where: Optional[List[str]] = None,
+        read_cache: bool = True,
+    ) -> "pa.Table": ...
+    @overload
+    def query(
+        self,
+        group_by: List[str],
+        limit: Optional[int] = None,
+        order_by: Optional[List[Union[str, OrderByGroupBy]]] = None,
         where: Optional[List[str]] = None,
         read_cache: bool = True,
     ) -> "pa.Table": ...

--- a/dbtsl/api/graphql/protocol.py
+++ b/dbtsl/api/graphql/protocol.py
@@ -219,7 +219,7 @@ def get_query_request_variables(environment_id: int, params: QueryParameters) ->
     if isinstance(strict_params, AdhocQueryParametersStrict):
         return {
             "savedQuery": None,
-            "metrics": [{"name": m} for m in strict_params.metrics],
+            "metrics": [{"name": m} for m in strict_params.metrics] if strict_params.metrics is not None else None,
             "groupBy": [{"name": g} for g in strict_params.group_by] if strict_params.group_by is not None else None,
             **shared_vars,
         }

--- a/dbtsl/api/shared/query_params.py
+++ b/dbtsl/api/shared/query_params.py
@@ -44,7 +44,7 @@ class QueryParameters(TypedDict, total=False):
 class AdhocQueryParametersStrict:
     """The parameters of an adhoc query, strictly validated."""
 
-    metrics: List[str]
+    metrics: Optional[List[str]]
     group_by: Optional[List[str]]
     limit: Optional[int]
     order_by: Optional[List[OrderBySpec]]
@@ -125,11 +125,8 @@ def validate_query_parameters(
             **shared_params,
         )
 
-    if "metrics" not in params or len(params["metrics"]) == 0:
-        raise ValueError("You need to specify at least one metric.")
-
     return AdhocQueryParametersStrict(
-        metrics=params["metrics"],
+        metrics=params.get("metrics"),
         group_by=params.get("group_by"),
         **shared_params,
     )

--- a/dbtsl/client/asyncio.pyi
+++ b/dbtsl/client/asyncio.pyi
@@ -27,6 +27,15 @@ class AsyncSemanticLayerClient:
     @overload
     async def compile_sql(
         self,
+        group_by: List[str],
+        limit: Optional[int] = None,
+        order_by: Optional[List[Union[str, OrderByGroupBy]]] = None,
+        where: Optional[List[str]] = None,
+        read_cache: bool = True,
+    ) -> str: ...
+    @overload
+    async def compile_sql(
+        self,
         saved_query: str,
         limit: Optional[int] = None,
         order_by: Optional[List[Union[OrderByGroupBy, OrderByMetric]]] = None,
@@ -44,6 +53,15 @@ class AsyncSemanticLayerClient:
         group_by: Optional[List[str]] = None,
         limit: Optional[int] = None,
         order_by: Optional[List[Union[str, OrderByGroupBy, OrderByMetric]]] = None,
+        where: Optional[List[str]] = None,
+        read_cache: bool = True,
+    ) -> "pa.Table": ...
+    @overload
+    async def query(
+        self,
+        group_by: List[str],
+        limit: Optional[int] = None,
+        order_by: Optional[List[Union[str, OrderByGroupBy]]] = None,
         where: Optional[List[str]] = None,
         read_cache: bool = True,
     ) -> "pa.Table": ...

--- a/dbtsl/client/sync.pyi
+++ b/dbtsl/client/sync.pyi
@@ -27,6 +27,15 @@ class SyncSemanticLayerClient:
     @overload
     def compile_sql(
         self,
+        group_by: List[str],
+        limit: Optional[int] = None,
+        order_by: Optional[List[Union[str, OrderByGroupBy]]] = None,
+        where: Optional[List[str]] = None,
+        read_cache: bool = True,
+    ) -> str: ...
+    @overload
+    def compile_sql(
+        self,
         saved_query: str,
         limit: Optional[int] = None,
         order_by: Optional[List[Union[OrderByGroupBy, OrderByMetric]]] = None,
@@ -44,6 +53,15 @@ class SyncSemanticLayerClient:
         group_by: Optional[List[str]] = None,
         limit: Optional[int] = None,
         order_by: Optional[List[Union[str, OrderByGroupBy, OrderByMetric]]] = None,
+        where: Optional[List[str]] = None,
+        read_cache: bool = True,
+    ) -> "pa.Table": ...
+    @overload
+    def query(
+        self,
+        group_by: List[str],
+        limit: Optional[int] = None,
+        order_by: Optional[List[Union[str, OrderByGroupBy]]] = None,
         where: Optional[List[str]] = None,
         read_cache: bool = True,
     ) -> "pa.Table": ...

--- a/tests/query_test_cases.py
+++ b/tests/query_test_cases.py
@@ -17,6 +17,10 @@ TEST_QUERIES: List[QueryParameters] = [
     {
         "metrics": ["order_total"],
     },
+    # ad hoc query, only group by
+    {
+        "group_by": ["customer__customer_type"],
+    },
     # ad hoc query, metric and group by
     {
         "metrics": ["order_total"],


### PR DESCRIPTION
This PR adds support for adhoc queries with only `group_by`, without a `metric`. This is equivalent to doing `client.dimension_values("my_dimension")`, but since the raw APIs support it, I thought it would be nice to keep parity here as well.

I changed the validation logic to allow this, and I added unit and integration test cases to cover it. I also changed the `.pyi` files so that users get LSP suggestions for this use case.

You can review by commit.