### PR TITLE
ci: fix CI that creates release titles

### DIFF
--- a/.changes/unreleased/Chore-20241114-150932.yaml
+++ b/.changes/unreleased/Chore-20241114-150932.yaml
@@ -1,0 +1,3 @@
+kind: Chore
+body: Fix release PR action to use correct title for PR
+time: 2024-11-14T15:09:32.92416+01:00

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
-          title: "version: ${{ steps.package-version.outputs.output }}"
+          title: "version: ${{ steps.package-version.outputs.version }}"
           branch: release/${{ steps.package-version.outputs.version }}
           commit-message: |
             version: ${{ steps.package-version.outputs.version }}


### PR DESCRIPTION
It was using the wrong version name, which resulted in PRs with the wrong name.