### PR TITLE
feat: increase maximum message size

### DIFF
--- a/.changes/unreleased/Features-20241213-104739.yaml
+++ b/.changes/unreleased/Features-20241213-104739.yaml
@@ -1,0 +1,3 @@
+kind: Features
+body: Double the max message size
+time: 2024-12-13T10:47:39.843647-07:00

--- a/dbtsl/api/adbc/client/base.py
+++ b/dbtsl/api/adbc/client/base.py
@@ -24,7 +24,7 @@ class BaseADBCClient:
             DatabaseOptions.WITH_COOKIE_MIDDLEWARE.value: "true",
             f"{DatabaseOptions.RPC_CALL_HEADER_PREFIX.value}user-agent": env.PLATFORM.user_agent,
             # double the default max msg size in case of queries with large batches
-            DatabaseOptions.WITH_MAX_MSG_SIZE: f"{1024 * 1024 * 32}",
+            DatabaseOptions.WITH_MAX_MSG_SIZE.value: f"{1024 * 1024 * 32}",
         }
 
     def __init__(  # noqa: D107

--- a/dbtsl/api/adbc/client/base.py
+++ b/dbtsl/api/adbc/client/base.py
@@ -23,6 +23,8 @@ class BaseADBCClient:
         return {
             DatabaseOptions.WITH_COOKIE_MIDDLEWARE.value: "true",
             f"{DatabaseOptions.RPC_CALL_HEADER_PREFIX.value}user-agent": env.PLATFORM.user_agent,
+            # double the default max msg size in case of queries with large batches
+            DatabaseOptions.WITH_MAX_MSG_SIZE: f"{1024 * 1024 * 32}",
         }
 
     def __init__(  # noqa: D107


### PR DESCRIPTION
A batch can contain up to 1024 rows. If the columns contain large
amounts of data (json blogs or free text), the total batch size can
exceed the max message size. By doubling this we should be able to
accommodate most use cases.

TODO: if we hear of people reaching this max, maybe we should make it
configurable.