### PR TITLE
ci: fix workflow to tag our releases

### DIFF
--- a/.github/workflows/create-release-tag.yaml
+++ b/.github/workflows/create-release-tag.yaml
@@ -13,6 +13,7 @@ jobs:
     if: "startsWith(github.event.head_commit.message, 'version:')"
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-python-env
       - name: Create tag
         run: |
           TAG=$(hatch version)

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - "*"
+      - '[0-9]+(\.[0-9]+)*([-\.]\S+)?'
 
 jobs:
   pypi-publish:


### PR DESCRIPTION
This commit hopefully fixes the Github Workflow that is used to create a version tag whenever we release.