### PR TITLE
feat: revamp timeouts

### DIFF
--- a/.changes/unreleased/Deprecations-20250212-124416.yaml
+++ b/.changes/unreleased/Deprecations-20250212-124416.yaml
@@ -1,0 +1,3 @@
+kind: Deprecations
+body: '`ExponentialBackoff.timeout_ms` is now deprecated. Prefer setting `total_timeout` in the global `TimeoutOptions`.'
+time: 2025-02-12T12:44:16.402691+01:00

--- a/.changes/unreleased/Features-20250211-174833.yaml
+++ b/.changes/unreleased/Features-20250211-174833.yaml
@@ -1,3 +1,3 @@
 kind: Features
-body: Added `timeout_ms` parameter to GraphQL clients
+body: Added `timeout` parameter to Semantic Layer client and to the underlying GraphQL clients
 time: 2025-02-11T17:48:33.204706+01:00

--- a/.changes/unreleased/Features-20250211-174833.yaml
+++ b/.changes/unreleased/Features-20250211-174833.yaml
@@ -1,0 +1,3 @@
+kind: Features
+body: Added `timeout_ms` parameter to GraphQL clients
+time: 2025-02-11T17:48:33.204706+01:00

--- a/.changes/unreleased/Features-20250212-131405.yaml
+++ b/.changes/unreleased/Features-20250212-131405.yaml
@@ -1,0 +1,3 @@
+kind: Features
+body: Added new `Connect`, `Execute` and `Retry` subclasses for `TimeoutError`
+time: 2025-02-12T13:14:05.827332+01:00

--- a/dbtsl/api/graphql/client/asyncio.py
+++ b/dbtsl/api/graphql/client/asyncio.py
@@ -31,6 +31,7 @@ class AsyncGraphQLClient(BaseGraphQLClient[AIOHTTPTransport, AsyncClientSession]
         environment_id: int,
         auth_token: str,
         url_format: Optional[str] = None,
+        timeout_ms: Optional[int] = None,
     ):
         """Initialize the metadata client.
 
@@ -41,12 +42,14 @@ class AsyncGraphQLClient(BaseGraphQLClient[AIOHTTPTransport, AsyncClientSession]
             url_format: The full connection URL format that transforms the `server_host`
                 into a full URL. If `None`, the default `https://{server_host}/api/graphql`
                 will be assumed.
+            timeout_ms: Timeout (in milliseconds) for all GraphQL requests.
         """
-        super().__init__(server_host, environment_id, auth_token, url_format)
+        super().__init__(server_host, environment_id, auth_token, url_format, timeout_ms)
 
     @override
-    def _create_transport(self, url: str, headers: Dict[str, str]) -> AIOHTTPTransport:
-        return AIOHTTPTransport(url=url, headers=headers)
+    def _create_transport(self, url: str, headers: Dict[str, str], timeout_ms: int) -> AIOHTTPTransport:
+        timeout_s = int(timeout_ms / 1_000)
+        return AIOHTTPTransport(url=url, headers=headers, timeout=timeout_s)
 
     @asynccontextmanager
     async def session(self) -> AsyncIterator[Self]:

--- a/dbtsl/api/graphql/client/asyncio.py
+++ b/dbtsl/api/graphql/client/asyncio.py
@@ -125,7 +125,7 @@ class AsyncGraphQLClient(BaseGraphQLClient[AIOHTTPTransport, AsyncClientSession]
             backoff = self._default_backoff()
 
         # support for deprecated ExponentialBackoff.timeout_ms
-        total_timeout = backoff.timeout_ms * 1000.0 if backoff.timeout_ms is not None else self.timeout.total_timeout
+        total_timeout_s = backoff.timeout_ms * 1000.0 if backoff.timeout_ms is not None else self.timeout.total_timeout
 
         start_s = time.time()
         for sleep_ms in backoff.iter_ms():
@@ -135,8 +135,8 @@ class AsyncGraphQLClient(BaseGraphQLClient[AIOHTTPTransport, AsyncClientSession]
                 return qr
 
             elapsed_s = time.time() - start_s
-            if elapsed_s > total_timeout:
-                raise RetryTimeoutError(timeout_s=self.timeout.total_timeout)
+            if elapsed_s > total_timeout_s:
+                raise RetryTimeoutError(timeout_s=total_timeout_s)
 
             await asyncio.sleep(sleep_ms / 1000)
 

--- a/dbtsl/api/graphql/client/asyncio.pyi
+++ b/dbtsl/api/graphql/client/asyncio.pyi
@@ -12,6 +12,7 @@ from dbtsl.models import (
     Metric,
     SavedQuery,
 )
+from dbtsl.timeout import TimeoutOptions
 
 class AsyncGraphQLClient:
     def __init__(
@@ -20,7 +21,7 @@ class AsyncGraphQLClient:
         environment_id: int,
         auth_token: str,
         url_format: Optional[str] = None,
-        timeout_ms: Optional[int] = None,
+        timeout: Optional[Union[TimeoutOptions, float, int]] = None,
     ) -> None: ...
     def session(self) -> AbstractAsyncContextManager[AsyncIterator[Self]]: ...
     @property

--- a/dbtsl/api/graphql/client/asyncio.pyi
+++ b/dbtsl/api/graphql/client/asyncio.pyi
@@ -20,6 +20,7 @@ class AsyncGraphQLClient:
         environment_id: int,
         auth_token: str,
         url_format: Optional[str] = None,
+        timeout_ms: Optional[int] = None,
     ) -> None: ...
     def session(self) -> AbstractAsyncContextManager[AsyncIterator[Self]]: ...
     @property

--- a/dbtsl/api/graphql/client/base.py
+++ b/dbtsl/api/graphql/client/base.py
@@ -30,12 +30,12 @@ class BaseGraphQLClient(Generic[TTransport, TSession]):
     PROTOCOL = GraphQLProtocol
     DEFAULT_URL_FORMAT = env.DEFAULT_GRAPHQL_URL_FORMAT
     DEFAULT_TIMEOUT = TimeoutOptions(
-        total_timeout=30,
+        total_timeout=60,
         # Ideally, connect timeouts are a little more than a multiple of 3, which
         # is the default packet retransmission window for TCP
         # See: https://datatracker.ietf.org/doc/html/rfc2988
         connect_timeout=4,
-        execute_timeout=10,
+        execute_timeout=60,
         tls_close_timeout=5,
     )
 

--- a/dbtsl/api/graphql/client/base.py
+++ b/dbtsl/api/graphql/client/base.py
@@ -82,7 +82,7 @@ class BaseGraphQLClient(Generic[TTransport, TSession]):
             **self._extra_headers(),
         }
         transport = self._create_transport(url=server_url, headers=headers)
-        self._gql = Client(transport=transport)
+        self._gql = Client(transport=transport, execute_timeout=self.timeout.execute_timeout)
 
         self._gql_session_unsafe: Union[TSession, None] = None
 

--- a/dbtsl/api/graphql/client/base.py
+++ b/dbtsl/api/graphql/client/base.py
@@ -45,7 +45,6 @@ class BaseGraphQLClient(Generic[TTransport, TSession]):
         return ExponentialBackoff(
             base_interval_ms=500,
             max_interval_ms=60000,
-            timeout_ms=90000,
         )
 
     @classmethod

--- a/dbtsl/api/graphql/client/sync.py
+++ b/dbtsl/api/graphql/client/sync.py
@@ -18,7 +18,7 @@ from dbtsl.api.graphql.protocol import (
 )
 from dbtsl.api.shared.query_params import QueryParameters
 from dbtsl.backoff import ExponentialBackoff
-from dbtsl.error import QueryFailedError
+from dbtsl.error import QueryFailedError, TimeoutError
 from dbtsl.models.query import QueryId, QueryStatus
 
 
@@ -105,13 +105,20 @@ class SyncGraphQLClient(BaseGraphQLClient[RequestsHTTPTransport, SyncClientSessi
         if backoff is None:
             backoff = self._default_backoff()
 
+        # support for deprecated ExponentialBackoff.timeout_ms
+        total_timeout = backoff.timeout_ms * 1000.0 if backoff.timeout_ms is not None else self.timeout.total_timeout
+
+        start_s = time.time()
         for sleep_ms in backoff.iter_ms():
-            # TODO: add timeout param to all requests because technically the API could hang and
-            # then we don't respect timeout.
             kwargs["query_id"] = query_id
+
             qr = self._run(poll_op, **kwargs)
             if qr.status in (QueryStatus.SUCCESSFUL, QueryStatus.FAILED):
                 return qr
+
+            elapsed_s = time.time() - start_s
+            if elapsed_s > total_timeout:
+                raise TimeoutError(timeout_s=self.timeout.total_timeout)
 
             time.sleep(sleep_ms / 1000)
 

--- a/dbtsl/api/graphql/client/sync.py
+++ b/dbtsl/api/graphql/client/sync.py
@@ -31,6 +31,7 @@ class SyncGraphQLClient(BaseGraphQLClient[RequestsHTTPTransport, SyncClientSessi
         environment_id: int,
         auth_token: str,
         url_format: Optional[str] = None,
+        timeout_ms: Optional[int] = None,
     ):
         """Initialize the metadata client.
 
@@ -41,12 +42,14 @@ class SyncGraphQLClient(BaseGraphQLClient[RequestsHTTPTransport, SyncClientSessi
             url_format: The full connection URL format that transforms the `server_host`
                 into a full URL. If `None`, the default `https://{server_host}/api/graphql`
                 will be assumed.
+            timeout_ms: Timeout (in milliseconds) for all GraphQL requests.
         """
-        super().__init__(server_host, environment_id, auth_token, url_format)
+        super().__init__(server_host, environment_id, auth_token, url_format, timeout_ms)
 
     @override
-    def _create_transport(self, url: str, headers: Dict[str, str]) -> RequestsHTTPTransport:
-        return RequestsHTTPTransport(url=url, headers=headers)
+    def _create_transport(self, url: str, headers: Dict[str, str], timeout_ms: int) -> RequestsHTTPTransport:
+        timeout_s = int(timeout_ms / 1_000)
+        return RequestsHTTPTransport(url=url, headers=headers, timeout=timeout_s)
 
     @contextmanager
     def session(self) -> Iterator[Self]:

--- a/dbtsl/api/graphql/client/sync.py
+++ b/dbtsl/api/graphql/client/sync.py
@@ -116,7 +116,7 @@ class SyncGraphQLClient(BaseGraphQLClient[RequestsHTTPTransport, SyncClientSessi
             backoff = self._default_backoff()
 
         # support for deprecated ExponentialBackoff.timeout_ms
-        total_timeout = backoff.timeout_ms * 1000.0 if backoff.timeout_ms is not None else self.timeout.total_timeout
+        total_timeout_s = backoff.timeout_ms * 1000.0 if backoff.timeout_ms is not None else self.timeout.total_timeout
 
         start_s = time.time()
         for sleep_ms in backoff.iter_ms():
@@ -127,8 +127,8 @@ class SyncGraphQLClient(BaseGraphQLClient[RequestsHTTPTransport, SyncClientSessi
                 return qr
 
             elapsed_s = time.time() - start_s
-            if elapsed_s > total_timeout:
-                raise RetryTimeoutError(timeout_s=self.timeout.total_timeout)
+            if elapsed_s > total_timeout_s:
+                raise RetryTimeoutError(timeout_s=total_timeout_s)
 
             time.sleep(sleep_ms / 1000)
 

--- a/dbtsl/api/graphql/client/sync.pyi
+++ b/dbtsl/api/graphql/client/sync.pyi
@@ -12,6 +12,7 @@ from dbtsl.models import (
     Metric,
     SavedQuery,
 )
+from dbtsl.timeout import TimeoutOptions
 
 class SyncGraphQLClient:
     def __init__(
@@ -20,7 +21,7 @@ class SyncGraphQLClient:
         environment_id: int,
         auth_token: str,
         url_format: Optional[str] = None,
-        timeout_ms: Optional[int] = None,
+        timeout: Optional[Union[TimeoutOptions, float, int]] = None,
     ) -> None: ...
     def session(self) -> AbstractContextManager[Iterator[Self]]: ...
     @property

--- a/dbtsl/api/graphql/client/sync.pyi
+++ b/dbtsl/api/graphql/client/sync.pyi
@@ -20,6 +20,7 @@ class SyncGraphQLClient:
         environment_id: int,
         auth_token: str,
         url_format: Optional[str] = None,
+        timeout_ms: Optional[int] = None,
     ) -> None: ...
     def session(self) -> AbstractContextManager[Iterator[Self]]: ...
     @property

--- a/dbtsl/backoff.py
+++ b/dbtsl/backoff.py
@@ -1,34 +1,37 @@
 import itertools
-import time
+import warnings
 from dataclasses import dataclass
-from typing import Iterator
+from typing import Iterator, Optional
 
-from dbtsl.error import TimeoutError
+TIMEOUT_MS_DEPRECATION = """
+Since the introduction of `TimeoutOptions`, the `timeout_ms` parameter on `ExponentialBackoff` has been deprecated.
+While it will still work, it might be removed in the future. Please migrate to setting the `total_timeout` on the
+global `TimeoutOptions` object.
+""".strip().replace("\n", " ")
 
 
-@dataclass
+@dataclass(frozen=True)
 class ExponentialBackoff:
     """Manage exponential backoff logic.
 
     Attributes:
         base_interval_ms: The interval to start with
         max_interval_ms: The maximum interval length
-        timeout_ms: After how long should it raise a TimeoutError
         exp_factor: The exponential factor to increase wait times
+        [deprecated] timeout_ms: After how long should it raise a TimeoutError
     """
 
     base_interval_ms: int
     max_interval_ms: int
-    timeout_ms: int
     exp_factor: float = 1.15
 
-    def iter_ms(self) -> Iterator[int]:
-        """Iterate over sleep times in ms until TimeoutError."""
-        start_ms = int(time.time() * 1000)
-        for i in itertools.count(start=0):
-            curr_ms = int(time.time() * 1000)
-            elapsed_ms = curr_ms - start_ms
-            if elapsed_ms > self.timeout_ms:
-                raise TimeoutError(timeout_ms=self.timeout_ms)
+    timeout_ms: Optional[int] = None
 
+    def __post_init__(self) -> None:  # noqa: D105
+        if self.timeout_ms is not None:
+            warnings.warn(TIMEOUT_MS_DEPRECATION, DeprecationWarning)
+
+    def iter_ms(self) -> Iterator[int]:
+        """Iterate over sleep times in ms according to the backoff configuration."""
+        for i in itertools.count(start=0):
             yield min(int(self.base_interval_ms * self.exp_factor**i), self.max_interval_ms)

--- a/dbtsl/client/asyncio.py
+++ b/dbtsl/client/asyncio.py
@@ -1,11 +1,12 @@
 from contextlib import asynccontextmanager
-from typing import AsyncIterator
+from typing import AsyncIterator, Optional, Union
 
 from typing_extensions import Self
 
 from dbtsl.api.adbc.client.asyncio import AsyncADBCClient
 from dbtsl.api.graphql.client.asyncio import AsyncGraphQLClient
 from dbtsl.client.base import BaseSemanticLayerClient
+from dbtsl.timeout import TimeoutOptions
 
 
 class AsyncSemanticLayerClient(BaseSemanticLayerClient[AsyncGraphQLClient, AsyncADBCClient]):  # type: ignore
@@ -24,6 +25,7 @@ class AsyncSemanticLayerClient(BaseSemanticLayerClient[AsyncGraphQLClient, Async
         environment_id: int,
         auth_token: str,
         host: str,
+        timeout: Optional[Union[TimeoutOptions, float, int]] = None,
     ) -> None:
         """Initialize the Semantic Layer client.
 
@@ -31,6 +33,7 @@ class AsyncSemanticLayerClient(BaseSemanticLayerClient[AsyncGraphQLClient, Async
             environment_id: your dbt environment ID
             auth_token: the API auth token
             host: the Semantic Layer API host
+            timeout: `TimeoutOptions` or total timeout for the underlying GraphQL client.
         """
         super().__init__(
             environment_id=environment_id,
@@ -38,6 +41,7 @@ class AsyncSemanticLayerClient(BaseSemanticLayerClient[AsyncGraphQLClient, Async
             host=host,
             gql_factory=AsyncGraphQLClient,
             adbc_factory=AsyncADBCClient,
+            timeout=timeout,
         )
 
     @asynccontextmanager

--- a/dbtsl/client/asyncio.pyi
+++ b/dbtsl/client/asyncio.pyi
@@ -6,6 +6,7 @@ from typing_extensions import Self, Unpack, overload
 
 from dbtsl.api.shared.query_params import OrderByGroupBy, OrderByMetric, QueryParameters
 from dbtsl.models import Dimension, Entity, Measure, Metric, SavedQuery
+from dbtsl.timeout import TimeoutOptions
 
 class AsyncSemanticLayerClient:
     def __init__(
@@ -13,6 +14,7 @@ class AsyncSemanticLayerClient:
         environment_id: int,
         auth_token: str,
         host: str,
+        timeout: Optional[Union[TimeoutOptions, float, int]] = None,
     ) -> None: ...
     @overload
     async def compile_sql(

--- a/dbtsl/client/base.py
+++ b/dbtsl/client/base.py
@@ -1,9 +1,10 @@
 from abc import ABC
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Optional, TypeVar, Union
 
 import dbtsl.env as env
 from dbtsl.api.adbc.client.base import ADBCClientFactory, BaseADBCClient
 from dbtsl.api.graphql.client.base import BaseGraphQLClient, GraphQLClientFactory
+from dbtsl.timeout import TimeoutOptions
 
 TGQLClient = TypeVar("TGQLClient", bound=BaseGraphQLClient)
 TADBCClient = TypeVar("TADBCClient", bound=BaseADBCClient)
@@ -38,6 +39,7 @@ class BaseSemanticLayerClient(ABC, Generic[TGQLClient, TADBCClient]):
         host: str,
         gql_factory: GraphQLClientFactory[TGQLClient],
         adbc_factory: ADBCClientFactory[TADBCClient],
+        timeout: Optional[Union[TimeoutOptions, float, int]] = None,
     ) -> None:
         """Initialize the Semantic Layer client.
 
@@ -47,6 +49,7 @@ class BaseSemanticLayerClient(ABC, Generic[TGQLClient, TADBCClient]):
             host: the Semantic Layer API host
             gql_factory: class of the underlying GQL client
             adbc_factory: class of the underlying ADBC client
+            timeout: `TimeoutOptions` or total timeout for the underlying GraphQL client.
         """
         self._has_session = False
 
@@ -57,6 +60,7 @@ class BaseSemanticLayerClient(ABC, Generic[TGQLClient, TADBCClient]):
             environment_id=environment_id,
             auth_token=auth_token,
             url_format=env.GRAPHQL_URL_FORMAT,
+            timeout=timeout,
         )
         self._adbc = adbc_factory(
             server_host=host,

--- a/dbtsl/client/sync.py
+++ b/dbtsl/client/sync.py
@@ -1,11 +1,12 @@
 from contextlib import contextmanager
-from typing import Iterator
+from typing import Iterator, Optional, Union
 
 from typing_extensions import Self
 
 from dbtsl.api.adbc.client.sync import SyncADBCClient
 from dbtsl.api.graphql.client.sync import SyncGraphQLClient
 from dbtsl.client.base import BaseSemanticLayerClient
+from dbtsl.timeout import TimeoutOptions
 
 
 class SyncSemanticLayerClient(BaseSemanticLayerClient[SyncGraphQLClient, SyncADBCClient]):  # type: ignore
@@ -24,6 +25,7 @@ class SyncSemanticLayerClient(BaseSemanticLayerClient[SyncGraphQLClient, SyncADB
         environment_id: int,
         auth_token: str,
         host: str,
+        timeout: Optional[Union[TimeoutOptions, float, int]] = None,
     ) -> None:
         """Initialize the Semantic Layer client.
 
@@ -31,6 +33,7 @@ class SyncSemanticLayerClient(BaseSemanticLayerClient[SyncGraphQLClient, SyncADB
             environment_id: your dbt environment ID
             auth_token: the API auth token
             host: the Semantic Layer API host
+            timeout: `TimeoutOptions` or total timeout for the underlying GraphQL client.
         """
         super().__init__(
             environment_id=environment_id,
@@ -38,6 +41,7 @@ class SyncSemanticLayerClient(BaseSemanticLayerClient[SyncGraphQLClient, SyncADB
             host=host,
             gql_factory=SyncGraphQLClient,
             adbc_factory=SyncADBCClient,
+            timeout=timeout,
         )
 
     @contextmanager

--- a/dbtsl/client/sync.pyi
+++ b/dbtsl/client/sync.pyi
@@ -6,6 +6,7 @@ from typing_extensions import Self, Unpack, overload
 
 from dbtsl.api.shared.query_params import OrderByGroupBy, OrderByMetric, QueryParameters
 from dbtsl.models import Dimension, Entity, Measure, Metric, SavedQuery
+from dbtsl.timeout import TimeoutOptions
 
 class SyncSemanticLayerClient:
     def __init__(
@@ -13,6 +14,7 @@ class SyncSemanticLayerClient:
         environment_id: int,
         auth_token: str,
         host: str,
+        timeout: Optional[Union[TimeoutOptions, float, int]] = None,
     ) -> None: ...
     @overload
     def compile_sql(

--- a/dbtsl/error.py
+++ b/dbtsl/error.py
@@ -31,6 +31,18 @@ class TimeoutError(SemanticLayerError):
         return f"{self.__class__.__name__}(timeout_s={self.timeout_s})"
 
 
+class ConnectTimeoutError(TimeoutError):
+    """Raise whenever a timeout occurred while connecting to the servers."""
+
+
+class ExecuteTimeoutError(TimeoutError):
+    """Raise whenever a timeout occurred while executing an operation against the servers."""
+
+
+class RetryTimeoutError(TimeoutError):
+    """Raise whenever a timeout occurred while retrying an operation against the servers."""
+
+
 class QueryFailedError(SemanticLayerError):
     """Raise whenever a query has failed."""
 

--- a/dbtsl/error.py
+++ b/dbtsl/error.py
@@ -17,18 +17,18 @@ class SemanticLayerError(RuntimeError):
 class TimeoutError(SemanticLayerError):
     """Raise whenever a request times out."""
 
-    def __init__(self, *args, timeout_ms: int, **kwargs) -> None:
+    def __init__(self, *args, timeout_s: float, **kwargs) -> None:
         """Initialize the timeout error.
 
         Args:
-            timeout_ms: The maximum time limit that got exceeded, in milliseconds
+            timeout_s: The maximum time limit that got exceeded, in seconds
             *args: any other exception args
             **kwargs: any other exception kwargs
         """
-        self.timeout_ms = timeout_ms
+        self.timeout_s = timeout_s
 
     def __str__(self) -> str:  # noqa: D105
-        return f"{self.__class__.__name__}(timeout_ms={self.timeout_ms})"
+        return f"{self.__class__.__name__}(timeout_s={self.timeout_s})"
 
 
 class QueryFailedError(SemanticLayerError):

--- a/dbtsl/timeout.py
+++ b/dbtsl/timeout.py
@@ -7,6 +7,10 @@ class TimeoutOptions:
 
     All values are in seconds.
 
+    All timeouts are upper-bounded by `total_timeout`. For example, if you provide `total_timeout=1` and
+    `connect_timeout=3`, the actual value of `connect_timeout` will be 1, since the connect timeout cannot
+    be bigger than the total timeout.
+
     Properties:
         total_timeout: total timeout for executing operations against the Semantic Layer, including
             connecting, executing (and retrying) operations, and closing the connection.
@@ -19,3 +23,8 @@ class TimeoutOptions:
     connect_timeout: float
     execute_timeout: float
     tls_close_timeout: float
+
+    def __post_init__(self) -> None:  # noqa: D105
+        object.__setattr__(self, "execute_timeout", min(self.execute_timeout, self.total_timeout))
+        object.__setattr__(self, "connect_timeout", min(self.connect_timeout, self.total_timeout))
+        object.__setattr__(self, "tls_close_timeout", min(self.tls_close_timeout, self.total_timeout))

--- a/dbtsl/timeout.py
+++ b/dbtsl/timeout.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TimeoutOptions:
+    """Timeout options for the GraphQL API.
+
+    All values are in seconds.
+
+    Properties:
+        total_timeout: total timeout for executing operations against the Semantic Layer, including
+            connecting, executing (and retrying) operations, and closing the connection.
+        connect_timeout: timeout for establishing a connection with the Semantic Layer services
+        execute_timeout: timeout for executing operations against the Semantic Layer services
+        tls_close_timeout: timeout for closing the TLS connection with the Semantic Layer services
+    """
+
+    total_timeout: float
+    connect_timeout: float
+    execute_timeout: float
+    tls_close_timeout: float

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,10 +79,3 @@ class Credentials:
 @pytest.fixture(scope="session")
 def credentials() -> Credentials:
     return Credentials.from_env()
-
-
-# generic method of requesting client that will automatically run once for sync
-# and once for async
-def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
-    if "client" in metafunc.fixturenames:
-        metafunc.parametrize("client", ["sync", "async"], indirect=True)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,37 @@
+import asyncio
+from typing import AsyncIterator, Union
+
+import pytest
+
+from dbtsl.client.asyncio import AsyncSemanticLayerClient
+from dbtsl.client.sync import SyncSemanticLayerClient
+
+BothClients = Union[SyncSemanticLayerClient, AsyncSemanticLayerClient]
+
+
+# generic method of requesting client that will automatically run once for sync
+# and once for async
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    if "client" in metafunc.fixturenames:
+        metafunc.parametrize("client", ["sync", "async"], indirect=True)
+
+    if "client_factory" in metafunc.fixturenames:
+        metafunc.parametrize("client_factory", ["sync", "async"], indirect=True)
+
+
+# We need to manually tear down the event loop after the tests stop running.
+# See: https://github.com/pytest-dev/pytest-asyncio/issues/200
+@pytest.fixture(scope="session", autouse=True)
+async def teardown() -> AsyncIterator[None]:
+    yield
+
+    event_loop = asyncio.get_running_loop()
+    tasks = [t for t in asyncio.all_tasks(event_loop) if not t.done()]
+
+    for task in tasks:
+        task.cancel()
+
+    try:
+        await asyncio.wait(tasks)
+    except asyncio.exceptions.CancelledError:
+        pass

--- a/tests/integration/test_sl_client.py
+++ b/tests/integration/test_sl_client.py
@@ -1,4 +1,4 @@
-from typing import AsyncIterator, Iterator, Union
+from typing import AsyncIterator, Iterator
 
 import pytest
 from pytest_subtests import SubTests
@@ -11,8 +11,7 @@ from dbtsl.client.sync import SyncSemanticLayerClient
 from ..conftest import Credentials
 from ..query_test_cases import TEST_QUERIES
 from ..util import maybe_await
-
-BothClients = Union[SyncSemanticLayerClient, AsyncSemanticLayerClient]
+from .conftest import BothClients
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_timeouts.py
+++ b/tests/integration/test_timeouts.py
@@ -1,0 +1,96 @@
+from typing import Callable
+
+import pytest
+
+from dbtsl.api.graphql.client.asyncio import NEW_AIOHTTP  # pyright: ignore[reportAttributeAccessIssue]
+from dbtsl.client.asyncio import AsyncSemanticLayerClient
+from dbtsl.client.sync import SyncSemanticLayerClient
+from dbtsl.error import ConnectTimeoutError, ExecuteTimeoutError, TimeoutError
+from dbtsl.timeout import TimeoutOptions
+
+from ..conftest import Credentials
+from ..util import maybe_async_with, maybe_await
+from .conftest import BothClients
+
+AsyncTimeoutClientFactory = Callable[[TimeoutOptions], AsyncSemanticLayerClient]
+SyncTimeoutClientFactory = Callable[[TimeoutOptions], SyncSemanticLayerClient]
+TimeoutClientFactory = Callable[[TimeoutOptions], BothClients]
+
+
+INF = 999999
+# timeouts can't actually be zero otherwise the networking libraries break
+# this shouldn't flake unless the packets somehow travel faster than light lol
+ZERO = 0.0000000000001
+
+
+@pytest.fixture(scope="module")
+def async_client_factory(credentials: Credentials) -> TimeoutClientFactory:
+    def factory(timeout: TimeoutOptions) -> AsyncSemanticLayerClient:
+        return AsyncSemanticLayerClient(
+            environment_id=credentials.environment_id,
+            auth_token=credentials.token,
+            host=credentials.host,
+            timeout=timeout,
+        )
+
+    return factory
+
+
+@pytest.fixture(scope="module")
+def sync_client_factory(credentials: Credentials) -> TimeoutClientFactory:
+    def factory(timeout: TimeoutOptions) -> SyncSemanticLayerClient:
+        return SyncSemanticLayerClient(
+            environment_id=credentials.environment_id,
+            auth_token=credentials.token,
+            host=credentials.host,
+            timeout=timeout,
+        )
+
+    return factory
+
+
+@pytest.fixture(scope="module")
+async def client_factory(
+    request: pytest.FixtureRequest,
+    sync_client_factory: TimeoutClientFactory,
+    async_client_factory: TimeoutClientFactory,
+) -> TimeoutClientFactory:
+    if request.param == "sync":
+        return sync_client_factory
+    return async_client_factory
+
+
+pytestmark = pytest.mark.asyncio(scope="module")
+
+
+# not testing async since `connect_timeout` doesn't work in aiohttp
+async def test_connect_timeout(sync_client_factory: SyncTimeoutClientFactory) -> None:
+    client = sync_client_factory(
+        TimeoutOptions(
+            connect_timeout=ZERO,
+            total_timeout=INF,
+            execute_timeout=INF,
+            tls_close_timeout=INF,
+        )
+    )
+    with pytest.raises(ConnectTimeoutError):
+        with client.session():
+            client.metrics()
+
+
+async def test_execute_timeout(client_factory: TimeoutClientFactory) -> None:
+    client = client_factory(
+        TimeoutOptions(
+            connect_timeout=INF,
+            total_timeout=INF,
+            execute_timeout=ZERO,
+            tls_close_timeout=INF,
+        )
+    )
+    with pytest.raises(TimeoutError) as exc_info:
+        async with maybe_async_with(client.session()):
+            await maybe_await(client.metrics())
+
+    # Narrow down the error in case we can do it
+    if isinstance(client, SyncSemanticLayerClient) or NEW_AIOHTTP:
+        assert isinstance(exc_info.value, ExecuteTimeoutError)

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -14,4 +14,4 @@ def test_error_repr_with_args() -> None:
 
 
 def test_timeout_error_str() -> None:
-    assert str(TimeoutError(timeout_ms=1000)) == "TimeoutError(timeout_ms=1000)"
+    assert str(TimeoutError(timeout_s=1000)) == "TimeoutError(timeout_s=1000)"

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -1,0 +1,17 @@
+from dbtsl.timeout import TimeoutOptions
+
+
+def test_timeout_options_is_upper_bounded_by_total_timeout() -> None:
+    t = TimeoutOptions(
+        connect_timeout=10,
+        execute_timeout=10,
+        tls_close_timeout=10,
+        total_timeout=1,
+    )
+    expected = TimeoutOptions(
+        connect_timeout=1,
+        execute_timeout=1,
+        tls_close_timeout=1,
+        total_timeout=1,
+    )
+    assert t == expected

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,12 +1,35 @@
 import inspect
+from contextlib import AbstractAsyncContextManager, AbstractContextManager, asynccontextmanager
 from typing import Awaitable, TypeVar, Union
 
 T = TypeVar("T")
 
 
 async def maybe_await(coro: Union[Awaitable[T], T]) -> T:
-    """Await if it's a coroutine, otherwise just return."""
+    """Await if it's a coroutine, otherwise just return.
+
+    This is useful for reusing tests for async/sync logic by just treating everything as
+    async.
+    """
     if inspect.iscoroutine(coro):
         return await coro
 
     return coro  # type: ignore
+
+
+def maybe_async_with(
+    ctx: Union[AbstractAsyncContextManager[T], AbstractContextManager[T]],
+) -> AbstractAsyncContextManager[T]:
+    """Always get an async context manager from any input context manager.
+
+    This allows you to run regular context managers in `async with` blocks.
+    """
+    if isinstance(ctx, AbstractAsyncContextManager):
+        return ctx
+
+    @asynccontextmanager
+    async def async_ctx():
+        with ctx as r:
+            yield r
+
+    return async_ctx()


### PR DESCRIPTION
This PR adds a new `timeout` parameter to the global `SemanticLayerClient` that gets passed down to the `GraphQLClient`.

The `timeout` parameter is a `TimeoutOptions` enum, which contains:
- `connection_timeout`: timeout to establish a connection to the servers
- `execute_timeout`: timeout to run an operation against the server (not counting retries)
- `tls_close_timeout`: timeout to close a TLS connection
- `total_timeout`: timeout for total wall time of an operation like `query()` or `dimensions()`, including retries, from the caller's point of view

Users can also pass in `int` or `float` values, which should be interpreted as equivalent to setting `total_timeout`. In practice, this gets converted to `TimeoutOptions` by assigning that same value to everything. Since everything should be upper-bounded by `total_timeout`, this should be fine.

Since I was at it, I deprecated the `timeout_ms` parameter in `ExponentialBackoff`. This value will be considered equivalent to `total_timeout` if provided, respecting the current behavior. If users use it, it will show a warning.

Finally, I improved the error handling logic of GraphQL clients so that internal `aiohttp` and `requests` timeout errors get re-raised as `dbtsl.TimeoutError`. This should make it easier for users to catch these errors without worrying about the underlying transport implementation.

You can review by commit.