### PR TITLE
Add support to pass in typed group by

### DIFF
--- a/.changes/unreleased/Features-20250327-224851.yaml
+++ b/.changes/unreleased/Features-20250327-224851.yaml
@@ -1,0 +1,3 @@
+kind: Features
+body: Add support to pass in typed group by
+time: 2025-03-27T22:48:51.368818-05:00

--- a/dbtsl/api/adbc/protocol.py
+++ b/dbtsl/api/adbc/protocol.py
@@ -4,6 +4,8 @@ from typing import Any, List, Mapping
 
 from dbtsl.api.shared.query_params import (
     DimensionValuesQueryParameters,
+    GroupByParam,
+    GroupByType,
     OrderByGroupBy,
     OrderByMetric,
     QueryParameters,
@@ -37,6 +39,17 @@ class ADBCProtocol:
             if val.descending:
                 d += ".descending(True)"
             return d
+
+        if isinstance(val, GroupByParam):
+            g: str = ""
+            if val.type == GroupByType.DIMENSION:
+                g = f'Dimension("{val.name}")'
+            elif val.type == GroupByType.ENTITY:
+                g = f'Entity("{val.name}")'
+            if val.grain:
+                grain_str = val.grain.lower()
+                g += f'.grain("{grain_str}")'
+            return g
 
         return json.dumps(val)
 

--- a/dbtsl/api/graphql/protocol.py
+++ b/dbtsl/api/graphql/protocol.py
@@ -220,7 +220,12 @@ def get_query_request_variables(environment_id: int, params: QueryParameters) ->
         return {
             "savedQuery": None,
             "metrics": [{"name": m} for m in strict_params.metrics] if strict_params.metrics is not None else None,
-            "groupBy": [{"name": g} for g in strict_params.group_by] if strict_params.group_by is not None else None,
+            "groupBy": [
+                {"name": g} if isinstance(g, str) else {"name": g.name, "timeGranularity": g.grain}
+                for g in strict_params.group_by
+            ]
+            if strict_params.group_by is not None
+            else None,
             **shared_vars,
         }
 

--- a/tests/api/adbc/test_protocol.py
+++ b/tests/api/adbc/test_protocol.py
@@ -1,5 +1,5 @@
 from dbtsl.api.adbc.protocol import ADBCProtocol
-from dbtsl.api.shared.query_params import OrderByGroupBy, OrderByMetric
+from dbtsl.api.shared.query_params import GroupByParam, GroupByType, OrderByGroupBy, OrderByMetric
 
 
 def test_serialize_val_basic_values() -> None:
@@ -70,6 +70,23 @@ def test_get_query_sql_simple_query() -> None:
     expected = (
         'SELECT * FROM {{ semantic_layer.query(metrics=["a","b"],'
         'order_by=[Metric("a").descending(True)],read_cache=True) }}'
+    )
+    assert sql == expected
+
+
+def test_get_query_sql_group_by_param() -> None:
+    sql = ADBCProtocol.get_query_sql(
+        params={
+            "metrics": ["a", "b"],
+            "group_by": [
+                GroupByParam(name="c", type=GroupByType.DIMENSION, grain="day"),
+                GroupByParam(name="d", type=GroupByType.ENTITY, grain="week"),
+            ],
+        }
+    )
+    expected = (
+        "SELECT * FROM {{ semantic_layer.query("
+        'group_by=[Dimension("c").grain("day"),Entity("d").grain("week")],metrics=["a","b"],read_cache=True) }}'
     )
     assert sql == expected
 

--- a/tests/query_test_cases.py
+++ b/tests/query_test_cases.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from dbtsl import OrderByGroupBy
-from dbtsl.api.shared.query_params import QueryParameters
+from dbtsl.api.shared.query_params import GroupByParam, GroupByType, QueryParameters
 
 TEST_QUERIES: List[QueryParameters] = [
     # ad hoc query, all parameters
@@ -37,5 +37,18 @@ TEST_QUERIES: List[QueryParameters] = [
     # saved query, no parameters
     {
         "saved_query": "order_metrics",
+    },
+    # group by param object
+    {
+        "metrics": ["order_total"],
+        "group_by": [GroupByParam(name="customer__customer_type", grain="month", type=GroupByType.DIMENSION)],
+    },
+    # multiple group by param objects
+    {
+        "metrics": ["order_total"],
+        "group_by": [
+            GroupByParam(name="customer__customer_type", grain="month", type=GroupByType.DIMENSION),
+            GroupByParam(name="customer__customer_type", grain="week", type=GroupByType.DIMENSION),
+        ],
     },
 ]


### PR DESCRIPTION
This PR adds the grain option to the group by field. This makes it easier to define a grain without using dunder syntax.