### PR TITLE
chore: Fix release CI regex

### DIFF
--- a/.changes/unreleased/Chore-20250327-101226.yaml
+++ b/.changes/unreleased/Chore-20250327-101226.yaml
@@ -1,0 +1,3 @@
+kind: Chore
+body: Fix release CI tags pattern
+time: 2025-03-27T10:12:26.06731+01:00

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - '[0-9]+(\.[0-9]+)*([-\.]\S+)?'
+      - '[0-9]+.[0-9]+.[0-9]+-[a-zA-Z]*'
 
 jobs:
   pypi-publish:


### PR DESCRIPTION
I found out that the `tags` field in the Github Workflow specification is not a regex, but their own pattern matcher syntax. This caused our release to fail, so I'm fixing it so we can release.