### PR TITLE
fix: Create `FlexibleEnumMeta` enum metaclass

### DIFF
--- a/.changes/unreleased/Fixes-20250327-184148.yaml
+++ b/.changes/unreleased/Fixes-20250327-184148.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Added `FlexibleEnumMeta` to make enums non-breaking when we add a new value to the API.
+time: 2025-03-27T18:41:48.001433+01:00

--- a/dbtsl/models/dimension.py
+++ b/dbtsl/models/dimension.py
@@ -2,13 +2,14 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import List, Optional
 
-from dbtsl.models.base import BaseModel, GraphQLFragmentMixin
+from dbtsl.models.base import BaseModel, FlexibleEnumMeta, GraphQLFragmentMixin
 from dbtsl.models.time import TimeGranularity
 
 
-class DimensionType(str, Enum):
+class DimensionType(Enum, metaclass=FlexibleEnumMeta):
     """The type of a dimension."""
 
+    UNKNOWN = "UNKNOWN"
     CATEGORICAL = "CATEGORICAL"
     TIME = "TIME"
 

--- a/dbtsl/models/entity.py
+++ b/dbtsl/models/entity.py
@@ -2,12 +2,13 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
-from dbtsl.models.base import BaseModel, GraphQLFragmentMixin
+from dbtsl.models.base import BaseModel, FlexibleEnumMeta, GraphQLFragmentMixin
 
 
-class EntityType(str, Enum):
+class EntityType(Enum, metaclass=FlexibleEnumMeta):
     """All supported entity types."""
 
+    UNKNOWN = "UNKNOWN"
     FOREIGN = "FOREIGN"
     NATURAL = "NATURAL"
     PRIMARY = "PRIMARY"

--- a/dbtsl/models/measure.py
+++ b/dbtsl/models/measure.py
@@ -2,12 +2,13 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
-from dbtsl.models.base import BaseModel, GraphQLFragmentMixin
+from dbtsl.models.base import BaseModel, FlexibleEnumMeta, GraphQLFragmentMixin
 
 
-class AggregationType(str, Enum):
+class AggregationType(Enum, metaclass=FlexibleEnumMeta):
     """All supported aggregation functions."""
 
+    UNKNOWN = "UNKNOWN"
     SUM = "SUM"
     MIN = "MIN"
     MAX = "MAX"

--- a/dbtsl/models/metric.py
+++ b/dbtsl/models/metric.py
@@ -2,16 +2,17 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import List, Optional
 
-from dbtsl.models.base import BaseModel, GraphQLFragmentMixin
+from dbtsl.models.base import BaseModel, FlexibleEnumMeta, GraphQLFragmentMixin
 from dbtsl.models.dimension import Dimension
 from dbtsl.models.entity import Entity
 from dbtsl.models.measure import Measure
 from dbtsl.models.time import TimeGranularity
 
 
-class MetricType(str, Enum):
+class MetricType(Enum, metaclass=FlexibleEnumMeta):
     """The type of a Metric."""
 
+    UNKNOWN = "UNKNOWN"
     SIMPLE = "SIMPLE"
     RATIO = "RATIO"
     CUMULATIVE = "CUMULATIVE"

--- a/dbtsl/models/query.py
+++ b/dbtsl/models/query.py
@@ -6,14 +6,15 @@ from typing import NewType, Optional
 
 import pyarrow as pa
 
-from dbtsl.models.base import BaseModel, GraphQLFragmentMixin
+from dbtsl.models.base import BaseModel, FlexibleEnumMeta, GraphQLFragmentMixin
 
 QueryId = NewType("QueryId", str)
 
 
-class QueryStatus(str, Enum):
+class QueryStatus(Enum, metaclass=FlexibleEnumMeta):
     """All the possible states of a query."""
 
+    UNKNOWN = "UNKNOWN"
     PENDING = "PENDING"
     RUNNING = "RUNNING"
     COMPILED = "COMPILED"

--- a/dbtsl/models/saved_query.py
+++ b/dbtsl/models/saved_query.py
@@ -3,13 +3,14 @@ from dataclasses import field as dc_field
 from enum import Enum
 from typing import List, Optional
 
-from dbtsl.models.base import BaseModel, GraphQLFragmentMixin
+from dbtsl.models.base import BaseModel, FlexibleEnumMeta, GraphQLFragmentMixin
 from dbtsl.models.time import DatePart, TimeGranularity
 
 
-class ExportDestinationType(str, Enum):
+class ExportDestinationType(Enum, metaclass=FlexibleEnumMeta):
     """All kinds of export destinations."""
 
+    UNKNOWN = "UNKNOWN"
     TABLE = "TABLE"
     VIEW = "VIEW"
 

--- a/dbtsl/models/time.py
+++ b/dbtsl/models/time.py
@@ -2,10 +2,10 @@ from enum import Enum
 
 from typing_extensions import override
 
-from dbtsl.models.base import DeprecatedMixin
+from dbtsl.models.base import DeprecatedMixin, FlexibleEnumMeta
 
 
-class TimeGranularity(str, DeprecatedMixin, Enum):
+class TimeGranularity(DeprecatedMixin, Enum, metaclass=FlexibleEnumMeta):
     """A time granularity."""
 
     @override
@@ -16,6 +16,7 @@ class TimeGranularity(str, DeprecatedMixin, Enum):
             "Please just use strings to represent time grains."
         )
 
+    UNKNOWN = "UNKNOWN"
     NANOSECOND = "NANOSECOND"
     MICROSECOND = "MICROSECOND"
     MILLISECOND = "MILLISECOND"
@@ -29,9 +30,10 @@ class TimeGranularity(str, DeprecatedMixin, Enum):
     YEAR = "YEAR"
 
 
-class DatePart(str, Enum):
+class DatePart(Enum, metaclass=FlexibleEnumMeta):
     """Date part."""
 
+    UNKNOWN = "UNKNOWN"
     DOY = "DOY"
     DOW = "DOW"
     DAY = "DAY"


### PR DESCRIPTION
This commit adds a new `FlexibleEnumMeta` enum metaclass that can be added to enums to make them accept arbitrary values as input and return a special `UNKNOWN` entry.

I added some tests that will assert all enums exported by the SDK will use this metaclass, and that all of them declare the `UNKNOWN` attribute with the correct value.