### PR TITLE
ci: add code checks on merge to `main` and publish

### DIFF
--- a/.changes/unreleased/Chore-20250331-133422.yaml
+++ b/.changes/unreleased/Chore-20250331-133422.yaml
@@ -1,0 +1,3 @@
+kind: Chore
+body: Add code quality check on merge to `main` and on publish to PyPI
+time: 2025-03-31T13:34:22.952433+02:00

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -1,11 +1,25 @@
 name: Code quality
 on:
+  workflow_dispatch:
+
+  workflow_call:
+    secrets:
+      TEST_HOST:
+        required: true
+      TEST_ENV_ID:
+        required: true
+      TEST_TOKEN:
+        required: true
+
   pull_request:
+
+  push:
+    branches:
+      - main
 
 jobs:
   code-quality:
     runs-on: ubuntu-latest
-    if: "!startsWith(github.event.pull_request.title, 'version:')"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,7 +6,15 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+-[a-zA-Z]*'
 
 jobs:
+  code-quality:
+    uses: ./.github/workflows/code-quality.yaml
+    secrets:
+      TEST_HOST: ${{ secrets.TEST_HOST }}
+      TEST_ENV_ID: ${{ secrets.TEST_ENV_ID }}
+      TEST_TOKEN: ${{ secrets.TEST_TOKEN }}
+
   pypi-publish:
+    needs: [code-quality]
     runs-on: ubuntu-latest
     environment: 
       name: release


### PR DESCRIPTION
This commit adds the code quality (lint, format, unit/integration tests) checks after merge to `main` and before publishing to PyPI. This is just an extra sanity check to be extra sure we won't publish bad code accidentally.