### PR TITLE
chore: make `pyright` run in `strict` mode and add `mypy`

### DIFF
--- a/.changes/unreleased/Chore-20250403-163034.yaml
+++ b/.changes/unreleased/Chore-20250403-163034.yaml
@@ -1,0 +1,3 @@
+kind: Chore
+body: Make `pyright` run on `strict` mode and add `mypy`.
+time: 2025-04-03T16:30:34.024926+02:00

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -32,7 +32,7 @@ jobs:
         run: "hatch run dev:basedpyright dbtsl tests"
 
       - name: mypy
-        run: "hatch run dev:python -m mypy dbtsl tests"
+        run: "hatch run dev:python -m mypy dbtsl"
 
       - name: fetch server schema
         run: "hatch run dev:fetch-schema"

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -29,7 +29,10 @@ jobs:
         run: "hatch run dev:ruff format --check"
 
       - name: basedpyright
-        run: "hatch run dev:basedpyright"
+        run: "hatch run dev:basedpyright dbtsl tests"
+
+      - name: mypy
+        run: "hatch run dev:python -m mypy dbtsl tests"
 
       - name: fetch server schema
         run: "hatch run dev:fetch-schema"

--- a/dbtsl/__init__.py
+++ b/dbtsl/__init__.py
@@ -1,11 +1,11 @@
-# pyright: reportUnusedImport=false
+# type: ignore
 try:
     from dbtsl.client.sync import SyncSemanticLayerClient
 
     SemanticLayerClient = SyncSemanticLayerClient
 except ImportError:
 
-    def err_factory(*args, **kwargs) -> None:  # noqa: D103
+    def err_factory(*_args: object, **_kwargs: object) -> None:  # noqa: D103
         raise ImportError(
             "You are trying to use the default `SemanticLayerClient`, "
             "but it looks like the necessary dependencies were not installed. "

--- a/dbtsl/api/adbc/client/asyncio.py
+++ b/dbtsl/api/adbc/client/asyncio.py
@@ -6,8 +6,7 @@ import pyarrow as pa
 from typing_extensions import Self, Unpack
 
 from dbtsl.api.adbc.client.base import BaseADBCClient
-from dbtsl.api.adbc.protocol import QueryParameters
-from dbtsl.api.shared.query_params import DimensionValuesQueryParameters
+from dbtsl.api.shared.query_params import DimensionValuesQueryParameters, QueryParameters
 
 
 class AsyncADBCClient(BaseADBCClient):
@@ -59,7 +58,7 @@ class AsyncADBCClient(BaseADBCClient):
         # just creating the cursor object doesn't perform any blocking IO.
         with self._conn.cursor() as cur:
             try:
-                await self._loop.run_in_executor(None, cur.execute, query_sql)
+                await self._loop.run_in_executor(None, cur.execute, query_sql)  # pyright: ignore[reportUnknownArgumentType,reportUnknownMemberType]
             except Exception as err:
                 self._handle_error(err)
             table = await self._loop.run_in_executor(None, cur.fetch_arrow_table)
@@ -74,7 +73,8 @@ class AsyncADBCClient(BaseADBCClient):
         # just creating the cursor object doesn't perform any blocking IO.
         with self._conn.cursor() as cur:
             try:
-                await self._loop.run_in_executor(None, cur.execute, query_sql)
+                await self._loop.run_in_executor(None, cur.execute, query_sql)  # pyright: ignore[reportUnknownArgumentType,reportUnknownMemberType]
+
             except Exception as err:
                 self._handle_error(err)
             table = await self._loop.run_in_executor(None, cur.fetch_arrow_table)

--- a/dbtsl/api/adbc/client/base.py
+++ b/dbtsl/api/adbc/client/base.py
@@ -4,7 +4,7 @@ from typing import Dict, Generic, Optional, Protocol, TypeVar, Union
 
 from adbc_driver_flightsql import DatabaseOptions
 from adbc_driver_flightsql.dbapi import Connection
-from adbc_driver_flightsql.dbapi import connect as adbc_connect
+from adbc_driver_flightsql.dbapi import connect as adbc_connect  # pyright: ignore[reportUnknownVariableType]
 from adbc_driver_manager import AdbcStatusCode, ProgrammingError
 
 import dbtsl.env as env

--- a/dbtsl/api/adbc/client/sync.py
+++ b/dbtsl/api/adbc/client/sync.py
@@ -5,8 +5,7 @@ import pyarrow as pa
 from typing_extensions import Self, Unpack
 
 from dbtsl.api.adbc.client.base import BaseADBCClient
-from dbtsl.api.adbc.protocol import QueryParameters
-from dbtsl.api.shared.query_params import DimensionValuesQueryParameters
+from dbtsl.api.shared.query_params import DimensionValuesQueryParameters, QueryParameters
 
 
 class SyncADBCClient(BaseADBCClient):
@@ -53,7 +52,7 @@ class SyncADBCClient(BaseADBCClient):
 
         with self._conn.cursor() as cur:
             try:
-                cur.execute(query_sql)
+                cur.execute(query_sql)  # pyright: ignore[reportUnknownMemberType]
             except Exception as err:
                 self._handle_error(err)
 
@@ -67,7 +66,7 @@ class SyncADBCClient(BaseADBCClient):
 
         with self._conn.cursor() as cur:
             try:
-                cur.execute(query_sql)
+                cur.execute(query_sql)  # pyright: ignore[reportUnknownMemberType]
             except Exception as err:
                 self._handle_error(err)
 

--- a/dbtsl/api/adbc/protocol.py
+++ b/dbtsl/api/adbc/protocol.py
@@ -20,7 +20,7 @@ class ADBCProtocol:
             return str(val)
 
         if isinstance(val, list):
-            list_str = ",".join(cls._serialize_val(list_val) for list_val in val)
+            list_str = ",".join(cls._serialize_val(list_val) for list_val in val)  # pyright: ignore[reportUnknownVariableType]
             return f"[{list_str}]"
 
         if isinstance(val, OrderByMetric):

--- a/dbtsl/api/graphql/client/asyncio.pyi
+++ b/dbtsl/api/graphql/client/asyncio.pyi
@@ -1,3 +1,5 @@
+# mypy: disable-error-code="misc"
+
 from contextlib import AbstractAsyncContextManager
 from typing import List, Optional, Self, Union
 

--- a/dbtsl/api/graphql/client/base.py
+++ b/dbtsl/api/graphql/client/base.py
@@ -1,4 +1,3 @@
-import functools
 import warnings
 from abc import abstractmethod
 from typing import Any, Dict, Generic, Optional, Protocol, TypeVar, Union
@@ -126,13 +125,15 @@ class BaseGraphQLClient(Generic[TTransport, TSession]):
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
-            return functools.partial(
-                self._run,
-                op=op,
-            )
+
+            def wrapped(**kwargs: Any) -> Any:
+                return self._run(op=op, raw_variables=kwargs)
+
+            return wrapped
 
 
-TClient = TypeVar("TClient", bound=BaseGraphQLClient, covariant=True)
+# TODO: have to type ignore, see: https://github.com/microsoft/pyright/issues/3497
+TClient = TypeVar("TClient", bound=BaseGraphQLClient, covariant=True)  # type: ignore
 
 
 class GraphQLClientFactory(Protocol, Generic[TClient]):  # noqa: D101

--- a/dbtsl/api/graphql/client/sync.pyi
+++ b/dbtsl/api/graphql/client/sync.pyi
@@ -1,3 +1,5 @@
+# mypy: disable-error-code="misc"
+
 from contextlib import AbstractContextManager
 from typing import Iterator, List, Optional, Union
 

--- a/dbtsl/api/shared/query_params.py
+++ b/dbtsl/api/shared/query_params.py
@@ -112,23 +112,26 @@ def validate_query_parameters(
 
         order_by = [validate_order_by(known_metrics, known_group_bys, clause) for clause in params["order_by"]]
 
-    shared_params = {
-        "limit": params.get("limit"),
-        "order_by": order_by,
-        "where": params.get("where"),
-        "read_cache": params.get("read_cache", True),
-    }
+    limit = params.get("limit")
+    where = params.get("where")
+    read_cache = params.get("read_cache", True)
 
     if is_saved_query:
         return SavedQueryQueryParametersStrict(
             saved_query=params["saved_query"],
-            **shared_params,
+            limit=limit,
+            order_by=order_by,
+            where=where,
+            read_cache=read_cache,
         )
 
     return AdhocQueryParametersStrict(
         metrics=params.get("metrics"),
         group_by=params.get("group_by"),
-        **shared_params,
+        limit=limit,
+        order_by=order_by,
+        where=where,
+        read_cache=read_cache,
     )
 
 

--- a/dbtsl/asyncio.py
+++ b/dbtsl/asyncio.py
@@ -1,9 +1,9 @@
-# pyright: reportUnusedImport=false
+# type: ignore
 try:
     from dbtsl.client.asyncio import AsyncSemanticLayerClient
 except ImportError:
 
-    def err_factory(*args, **kwargs) -> None:  # noqa: D103
+    def err_factory(*_args: object, **_kwargs: object) -> None:  # noqa: D103
         raise ImportError(
             "You are trying to use the asyncio `AsyncSemanticLayerClient`, "
             "but it looks like the necessary dependencies were not installed. "

--- a/dbtsl/client/asyncio.pyi
+++ b/dbtsl/client/asyncio.pyi
@@ -1,3 +1,5 @@
+# mypy: disable-error-code="misc"
+
 from contextlib import AbstractAsyncContextManager
 from typing import AsyncIterator, List, Optional, Union
 

--- a/dbtsl/client/base.py
+++ b/dbtsl/client/base.py
@@ -6,7 +6,8 @@ from dbtsl.api.adbc.client.base import ADBCClientFactory, BaseADBCClient
 from dbtsl.api.graphql.client.base import BaseGraphQLClient, GraphQLClientFactory
 from dbtsl.timeout import TimeoutOptions
 
-TGQLClient = TypeVar("TGQLClient", bound=BaseGraphQLClient)
+# TODO: have to type ignore, see: https://github.com/microsoft/pyright/issues/3497
+TGQLClient = TypeVar("TGQLClient", bound=BaseGraphQLClient)  # type: ignore
 TADBCClient = TypeVar("TADBCClient", bound=BaseADBCClient)
 
 ADBC = "adbc"
@@ -86,7 +87,7 @@ class BaseSemanticLayerClient(ABC, Generic[TGQLClient, TADBCClient]):
         assert target_str in (ADBC, GRAPHQL)
         target = self._gql if target_str == GRAPHQL else self._adbc
 
-        attr_val = getattr(target, attr, None)
+        attr_val = getattr(target, attr, None)  # pyright: ignore[reportUnknownArgumentType]
 
         if attr_val is None or not callable(attr_val):
             raise AttributeError()

--- a/dbtsl/client/sync.pyi
+++ b/dbtsl/client/sync.pyi
@@ -1,3 +1,5 @@
+# mypy: disable-error-code="misc"
+
 from contextlib import AbstractContextManager
 from typing import Iterator, List, Optional, Union
 

--- a/dbtsl/error.py
+++ b/dbtsl/error.py
@@ -17,7 +17,7 @@ class SemanticLayerError(RuntimeError):
 class TimeoutError(SemanticLayerError):
     """Raise whenever a request times out."""
 
-    def __init__(self, *args, timeout_s: float, **kwargs) -> None:
+    def __init__(self, *, timeout_s: float, **_kwargs: object) -> None:
         """Initialize the timeout error.
 
         Args:

--- a/dbtsl/models/__init__.py
+++ b/dbtsl/models/__init__.py
@@ -25,7 +25,7 @@ from .time import DatePart, TimeGranularity
 # Only importing this so it registers aliases
 _ = QueryResult
 
-BaseModel._register_subclasses()
+BaseModel._register_subclasses()  # pyright: ignore[reportPrivateUsage]
 
 __all__ = [
     "AggregationType",

--- a/dbtsl/models/base.py
+++ b/dbtsl/models/base.py
@@ -28,15 +28,21 @@ class FlexibleEnumMeta(EnumMeta):
 
     UNKNOWN = "UNKNOWN"
 
-    def __new__(metacls: Type["FlexibleEnumMeta"], name: str, bases: Tuple[Type], namespace: Dict[str, Any], **kwargs):
+    def __new__(
+        metacls: Type["FlexibleEnumMeta"],
+        name: str,
+        bases: Tuple[Type[object]],
+        namespace: Dict[str, Any],
+        **_kwargs: object,
+    ) -> "FlexibleEnumMeta":
         """Overwrite the _missing_ method of enum classes."""
         msg = f"Class {name} needs UNKNOWN attribute with 'UNKNOWN' string value"
         assert namespace.get("UNKNOWN", None) == "UNKNOWN", msg
 
         metacls._subclass_registry.add(name)
 
-        newclass = super().__new__(metacls, name, bases, namespace)  # pyright: ignore[reportArgumentType]
-        setattr(newclass, "_missing_", classmethod(metacls._missing_))  # pyright: ignore[reportArgumentType]
+        newclass = super().__new__(metacls, name, bases, namespace)  # type: ignore
+        setattr(newclass, "_missing_", classmethod(metacls._missing_))  # type: ignore
         return newclass
 
     def __getitem__(cls, name: str) -> Any:
@@ -89,9 +95,7 @@ class BaseModel(DataClassDictMixin):
             for field in fields(subclass):
                 camel_name = snake_case_to_camel_case(field.name)
                 if field.name != camel_name:
-                    opts = field_options(alias=camel_name)
-                    if field.metadata is not None:
-                        opts = {**opts, **field.metadata}
+                    opts = {**field_options(alias=camel_name), **field.metadata}
                     field.metadata = MappingProxyType(opts)
 
                 if cls.DEPRECATED in field.metadata:
@@ -115,7 +119,7 @@ class DeprecatedMixin:
         """The deprecation message that will get displayed."""
         return f"{cls.__name__} is deprecated"
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: D107
+    def __init__(self, *_args: object, **_kwargs: object) -> None:  # noqa: D107
         warnings.warn(self._deprecation_message(), DeprecationWarning)
         super(DeprecatedMixin, self).__init__()
 

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -7,7 +7,9 @@ pre-commit:
       run: "hatch run dev:ruff check --fix"
       stage_fixed: true
     pyright:
-      run: "hatch run dev:basedpyright"
+      run: "hatch run dev:basedpyright dbtsl tests"
+    mypy:
+      run: "hatch run dev:python -m mypy dbtsl tests"
 
 commit-msg:
   scripts:

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -9,7 +9,7 @@ pre-commit:
     pyright:
       run: "hatch run dev:basedpyright dbtsl tests"
     mypy:
-      run: "hatch run dev:python -m mypy dbtsl tests"
+      run: "hatch run dev:python -m mypy dbtsl"
 
 commit-msg:
   scripts:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,10 +128,20 @@ PIP_EXTRA_INDEX_URL = "https://pypi.org/simple/"
 asyncio_mode = "auto"
 
 [tool.pyright]
-# TODO: we'd love to enable "strict" typechecking, but 
-# pyarrow not having type stubs makes that really hard
 typeCheckingMode = "strict"
 venv = ".venv/"
+
+[[tool.pyright.executionEnvironments]]
+root = "tests"
+# Tests use private methods and assign inappropriate values to some
+# properties to check our error handling capabilities etc. To avoid
+# having to ignore everything, we disable some checks
+reportPrivateUsage = false
+reportAssignmentType = false
+reportAny = false
+reportCallIssue = false
+reportArgumentType = false
+reportUnknownMemberType = false
 
 [tool.mypy]
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ sync = ["gql[requests]>=3.5.0,<4.0.0"]
 dev = [
   "ruff",
   "basedpyright",
+  "mypy",
   "uv",
 ]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
 async = ["gql[aiohttp]>=3.5.0,<4.0.0"]
 sync = ["gql[requests]>=3.5.0,<4.0.0"]
 dev = [
+  "pyarrow-stubs",
   "ruff",
   "basedpyright",
   "mypy",
@@ -129,8 +130,11 @@ asyncio_mode = "auto"
 [tool.pyright]
 # TODO: we'd love to enable "strict" typechecking, but 
 # pyarrow not having type stubs makes that really hard
-typeCheckingMode = "standard"
+typeCheckingMode = "strict"
 venv = ".venv/"
+
+[tool.mypy]
+strict = true
 
 [tool.black]
 line-length = 120

--- a/tests/api/graphql/test_protocol.py
+++ b/tests/api/graphql/test_protocol.py
@@ -7,7 +7,7 @@ from dbtsl.api.graphql.protocol import GraphQLProtocol
 from ...conftest import QueryValidator
 from ...query_test_cases import TEST_QUERIES
 
-VARIABLES = {
+VARIABLES: dict[str, list[dict[str, Any]]] = {
     "metrics": [{}],
     "dimensions": [{"metrics": ["m"]}],
     "measures": [{"metrics": ["m"]}],
@@ -48,5 +48,5 @@ def test_queries_are_valid(test_case: TestCase, validate_query: QueryValidator) 
 
     op = getattr(GraphQLProtocol, op_name)
     query = op.get_request_text()
-    variable_values = op.get_request_variables(environment_id=123, **raw_variables)
+    variable_values = op.get_request_variables(environment_id=123, variables=raw_variables)
     validate_query(query, variable_values)

--- a/tests/integration/test_sl_client.py
+++ b/tests/integration/test_sl_client.py
@@ -82,14 +82,13 @@ async def test_client_metadata(subtests: SubTests, client: BothClients) -> None:
 @pytest.mark.parametrize("query", TEST_QUERIES)
 async def test_client_query(api: str, query: QueryParameters, client: BothClients) -> None:
     client._method_map["query"] = api  # type: ignore
-    # TODO: fix typing on client.query
     table = await maybe_await(client.query(**query))  # type: ignore
-    assert len(table) > 0
+    assert len(table) > 0  # type: ignore
 
 
 @pytest.mark.parametrize("query", TEST_QUERIES)
 async def test_client_compile_sql_adhoc_query(query: QueryParameters, client: BothClients) -> None:
     # TODO: fix typing on client.compile_sql
     sql = await maybe_await(client.compile_sql(**query))  # type: ignore
-    assert len(sql) > 0
+    assert len(sql) > 0  # type: ignore
     assert "SELECT" in sql

--- a/tests/integration/test_timeouts.py
+++ b/tests/integration/test_timeouts.py
@@ -2,7 +2,7 @@ from typing import Callable
 
 import pytest
 
-from dbtsl.api.graphql.client.asyncio import NEW_AIOHTTP  # pyright: ignore[reportAttributeAccessIssue]
+from dbtsl.api.graphql.client.asyncio import _new_aiohttp  # type: ignore
 from dbtsl.client.asyncio import AsyncSemanticLayerClient
 from dbtsl.client.sync import SyncSemanticLayerClient
 from dbtsl.error import ConnectTimeoutError, ExecuteTimeoutError, TimeoutError
@@ -92,5 +92,5 @@ async def test_execute_timeout(client_factory: TimeoutClientFactory) -> None:
             await maybe_await(client.metrics())
 
     # Narrow down the error in case we can do it
-    if isinstance(client, SyncSemanticLayerClient) or NEW_AIOHTTP:
+    if isinstance(client, SyncSemanticLayerClient) or _new_aiohttp:
         assert isinstance(exc_info.value, ExecuteTimeoutError)


### PR DESCRIPTION
## Summary

This PR upgrade pyright `typeCheckingMode` from `standard` to `strict`, and it also adds `mypy` typechecking to the pre-commit hooks and to CI.

This is an attempt to make sure our type definitions are very sound, and will hopefully catch some bugs in the future.

There were some exceptions where I had to resort to `# type: ignore`. 

Most of them are due to incomplete type annotations on third party libraries, which triggers the `reportUnknownArgumentType` or `reportUnknownVariable` checks from pyright (cough cough `pyarrow`).

Some other exceptions are due to there being to way to type things like `Unpack[T]` where `T` is not a concrete `TypedDict` and is instead a `TypeVar` that is bound to a `TypedDict`. In such cases, I added comments explaining why the ignore is necessary. Yes, I could rewrite the whole API to make it fully type-able, but that would also make the code a lot more verbose probably.

You can review commit by commit.