### PR TITLE
Fix type of group_by in query method

### DIFF
--- a/.changes/unreleased/Fixes-20250409-201106.yaml
+++ b/.changes/unreleased/Fixes-20250409-201106.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Fix type of group_by in query method
+time: 2025-04-09T20:11:06.83741-05:00

--- a/dbtsl/api/graphql/client/asyncio.pyi
+++ b/dbtsl/api/graphql/client/asyncio.pyi
@@ -6,7 +6,7 @@ from typing import List, Optional, Self, Union
 import pyarrow as pa
 from typing_extensions import AsyncIterator, Unpack, overload
 
-from dbtsl.api.shared.query_params import OrderByGroupBy, OrderByMetric, QueryParameters
+from dbtsl.api.shared.query_params import GroupByParam, OrderByGroupBy, OrderByMetric, QueryParameters
 from dbtsl.models import (
     Dimension,
     Entity,
@@ -84,7 +84,7 @@ class AsyncGraphQLClient:
     async def query(
         self,
         metrics: List[str],
-        group_by: Optional[List[str]] = None,
+        group_by: Optional[List[Union[GroupByParam, str]]] = None,
         limit: Optional[int] = None,
         order_by: Optional[List[Union[str, OrderByGroupBy, OrderByMetric]]] = None,
         where: Optional[List[str]] = None,
@@ -93,7 +93,7 @@ class AsyncGraphQLClient:
     @overload
     async def query(
         self,
-        group_by: List[str],
+        group_by: List[Union[GroupByParam, str]],
         limit: Optional[int] = None,
         order_by: Optional[List[Union[str, OrderByGroupBy]]] = None,
         where: Optional[List[str]] = None,

--- a/dbtsl/api/graphql/client/sync.pyi
+++ b/dbtsl/api/graphql/client/sync.pyi
@@ -6,7 +6,7 @@ from typing import Iterator, List, Optional, Union
 import pyarrow as pa
 from typing_extensions import Self, Unpack, overload
 
-from dbtsl.api.shared.query_params import OrderByGroupBy, OrderByMetric, QueryParameters
+from dbtsl.api.shared.query_params import GroupByParam, OrderByGroupBy, OrderByMetric, QueryParameters
 from dbtsl.models import (
     Dimension,
     Entity,
@@ -84,7 +84,7 @@ class SyncGraphQLClient:
     def query(
         self,
         metrics: List[str],
-        group_by: Optional[List[str]] = None,
+        group_by: Optional[List[Union[GroupByParam, str]]] = None,
         limit: Optional[int] = None,
         order_by: Optional[List[Union[str, OrderByGroupBy, OrderByMetric]]] = None,
         where: Optional[List[str]] = None,
@@ -93,7 +93,7 @@ class SyncGraphQLClient:
     @overload
     def query(
         self,
-        group_by: List[str],
+        group_by: List[Union[GroupByParam, str]],
         limit: Optional[int] = None,
         order_by: Optional[List[Union[str, OrderByGroupBy]]] = None,
         where: Optional[List[str]] = None,

--- a/dbtsl/api/shared/query_params.py
+++ b/dbtsl/api/shared/query_params.py
@@ -4,6 +4,8 @@ from typing import List, Optional, TypedDict, Union
 
 
 class GroupByType(Enum):
+    """The type of a group_by, i.e a dimension or an entity."""
+
     DIMENSION = "dimension"
     ENTITY = "entity"
 

--- a/dbtsl/client/asyncio.pyi
+++ b/dbtsl/client/asyncio.pyi
@@ -6,7 +6,7 @@ from typing import AsyncIterator, List, Optional, Union
 import pyarrow as pa
 from typing_extensions import Self, Unpack, overload
 
-from dbtsl.api.shared.query_params import OrderByGroupBy, OrderByMetric, QueryParameters
+from dbtsl.api.shared.query_params import GroupByParam, OrderByGroupBy, OrderByMetric, QueryParameters
 from dbtsl.models import Dimension, Entity, Measure, Metric, SavedQuery
 from dbtsl.timeout import TimeoutOptions
 
@@ -54,7 +54,7 @@ class AsyncSemanticLayerClient:
     async def query(
         self,
         metrics: List[str],
-        group_by: Optional[List[str]] = None,
+        group_by: Optional[List[Union[GroupByParam, str]]] = None,
         limit: Optional[int] = None,
         order_by: Optional[List[Union[str, OrderByGroupBy, OrderByMetric]]] = None,
         where: Optional[List[str]] = None,

--- a/dbtsl/client/sync.pyi
+++ b/dbtsl/client/sync.pyi
@@ -6,7 +6,7 @@ from typing import Iterator, List, Optional, Union
 import pyarrow as pa
 from typing_extensions import Self, Unpack, overload
 
-from dbtsl.api.shared.query_params import OrderByGroupBy, OrderByMetric, QueryParameters
+from dbtsl.api.shared.query_params import GroupByParam, OrderByGroupBy, OrderByMetric, QueryParameters
 from dbtsl.models import Dimension, Entity, Measure, Metric, SavedQuery
 from dbtsl.timeout import TimeoutOptions
 
@@ -54,7 +54,7 @@ class SyncSemanticLayerClient:
     def query(
         self,
         metrics: List[str],
-        group_by: Optional[List[str]] = None,
+        group_by: Optional[List[Union[GroupByParam, str]]] = None,
         limit: Optional[int] = None,
         order_by: Optional[List[Union[str, OrderByGroupBy, OrderByMetric]]] = None,
         where: Optional[List[str]] = None,
@@ -63,7 +63,7 @@ class SyncSemanticLayerClient:
     @overload
     def query(
         self,
-        group_by: List[str],
+        group_by: List[Union[GroupByParam, str]],
         limit: Optional[int] = None,
         order_by: Optional[List[Union[str, OrderByGroupBy]]] = None,
         where: Optional[List[str]] = None,


### PR DESCRIPTION
In [my last PR](https://github.com/dbt-labs/semantic-layer-sdk-python/pull/70), I neglected to update the type information for the query method in some instances. This fixes that by allowing `Union[GroupByParam, str]` instead of just `str` for group_by params.