### PR TITLE
feat: add lazy loading

### DIFF
--- a/.changes/unreleased/Features-20250414-170939.yaml
+++ b/.changes/unreleased/Features-20250414-170939.yaml
@@ -1,0 +1,3 @@
+kind: Features
+body: Add `lazy` parameter to clients which allows lazy loading of certain model fields.
+time: 2025-04-14T17:09:39.64588+02:00

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ arrow_table = client.query(...)
 polars_df = pl.from_arrow(arrow_table)
 ```
 
+### Lazy loading
+
+By default, the SDK will eagerly request for lists of nested objects. For example, in the list of `Metric` returned by `client.metrics()`, each metric will contain the list of its dimensions, entities and measures. This is convenient in most cases, but can make your returned data really large in case your project is really large, which can slow things down. 
+
+It is possible to set the client to `lazy=True`, which will make it skip populating nested object lists unless you explicitly load ask for it on a per-model basis. Check your [lazy loading example](./examples/list_metrics_lazy_sync.py) to learn more.
+
 ### More examples
 
 Check out our [usage examples](./examples/) to learn more.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ polars_df = pl.from_arrow(arrow_table)
 
 By default, the SDK will eagerly request for lists of nested objects. For example, in the list of `Metric` returned by `client.metrics()`, each metric will contain the list of its dimensions, entities and measures. This is convenient in most cases, but can make your returned data really large in case your project is really large, which can slow things down. 
 
-It is possible to set the client to `lazy=True`, which will make it skip populating nested object lists unless you explicitly load ask for it on a per-model basis. Check your [lazy loading example](./examples/list_metrics_lazy_sync.py) to learn more.
+It is possible to set the client to `lazy=True`, which will make it skip populating nested object lists unless you explicitly load ask for it on a per-model basis. Check our [lazy loading example](./examples/list_metrics_lazy_sync.py) to learn more.
 
 ### More examples
 

--- a/dbtsl/api/graphql/client/asyncio.py
+++ b/dbtsl/api/graphql/client/asyncio.py
@@ -117,8 +117,9 @@ class AsyncGraphQLClient(BaseGraphQLClient[AIOHTTPTransport, AsyncClientSession]
         except Exception as err:
             raise self._refine_err(err)
 
-        res["_client"] = self
-        return op.parse_response(res)
+        resp = op.parse_response(res)
+        self._attach_self_to_parsed_response(resp)
+        return resp
 
     async def _poll_until_complete(
         self,

--- a/dbtsl/api/graphql/client/asyncio.py
+++ b/dbtsl/api/graphql/client/asyncio.py
@@ -117,6 +117,7 @@ class AsyncGraphQLClient(BaseGraphQLClient[AIOHTTPTransport, AsyncClientSession]
         except Exception as err:
             raise self._refine_err(err)
 
+        res["_client"] = self
         return op.parse_response(res)
 
     async def _poll_until_complete(

--- a/dbtsl/api/graphql/client/asyncio.py
+++ b/dbtsl/api/graphql/client/asyncio.py
@@ -49,6 +49,8 @@ class AsyncGraphQLClient(BaseGraphQLClient[AIOHTTPTransport, AsyncClientSession]
         auth_token: str,
         url_format: Optional[str] = None,
         timeout: Optional[Union[TimeoutOptions, float, int]] = None,
+        *,
+        lazy: bool,
     ):
         """Initialize the metadata client.
 
@@ -60,12 +62,13 @@ class AsyncGraphQLClient(BaseGraphQLClient[AIOHTTPTransport, AsyncClientSession]
                 into a full URL. If `None`, the default `https://{server_host}/api/graphql`
                 will be assumed.
             timeout: TimeoutOptions or total timeout (in seconds) for all GraphQL requests.
+            lazy: Whether to lazy load large subfields
 
         NOTE: If `timeout` is a `TimeoutOptions`, the `connect_timeout` will not be used, due to
         limitations of `gql`'s `aiohttp` transport.
         See: https://github.com/graphql-python/gql/blob/b066e8944b0da0a4bbac6c31f43e5c3c7772cd51/gql/transport/aiohttp.py#L110
         """
-        super().__init__(server_host, environment_id, auth_token, url_format, timeout)
+        super().__init__(server_host, environment_id, auth_token, url_format, timeout, lazy=lazy)
 
     @override
     def _create_transport(self, url: str, headers: Dict[str, str]) -> AIOHTTPTransport:
@@ -97,7 +100,7 @@ class AsyncGraphQLClient(BaseGraphQLClient[AIOHTTPTransport, AsyncClientSession]
 
     async def _run(self, op: ProtocolOperation[TVariables, TResponse], raw_variables: TVariables) -> TResponse:
         """Run a `ProtocolOperation`."""
-        raw_query = op.get_request_text()
+        raw_query = op.get_request_text(lazy=self.lazy)
         variables = op.get_request_variables(environment_id=self.environment_id, variables=raw_variables)
         gql_query = gql(raw_query)
 

--- a/dbtsl/api/graphql/client/asyncio.pyi
+++ b/dbtsl/api/graphql/client/asyncio.pyi
@@ -8,10 +8,10 @@ from typing_extensions import AsyncIterator, Unpack, overload
 
 from dbtsl.api.shared.query_params import GroupByParam, OrderByGroupBy, OrderByMetric, QueryParameters
 from dbtsl.models import (
+    AsyncMetric,
     Dimension,
     Entity,
     Measure,
-    Metric,
     SavedQuery,
 )
 from dbtsl.timeout import TimeoutOptions
@@ -30,7 +30,7 @@ class AsyncGraphQLClient:
     def session(self) -> AbstractAsyncContextManager[AsyncIterator[Self]]: ...
     @property
     def has_session(self) -> bool: ...
-    async def metrics(self) -> List[Metric]:
+    async def metrics(self) -> List[AsyncMetric]:
         """Get a list of all available metrics."""
         ...
 

--- a/dbtsl/api/graphql/client/asyncio.pyi
+++ b/dbtsl/api/graphql/client/asyncio.pyi
@@ -24,6 +24,8 @@ class AsyncGraphQLClient:
         auth_token: str,
         url_format: Optional[str] = None,
         timeout: Optional[Union[TimeoutOptions, float, int]] = None,
+        *,
+        lazy: bool,
     ) -> None: ...
     def session(self) -> AbstractAsyncContextManager[AsyncIterator[Self]]: ...
     @property

--- a/dbtsl/api/graphql/client/base.py
+++ b/dbtsl/api/graphql/client/base.py
@@ -13,6 +13,7 @@ from dbtsl.api.graphql.protocol import (
 )
 from dbtsl.backoff import ExponentialBackoff
 from dbtsl.error import AuthError
+from dbtsl.models.base import GraphQLFragmentMixin
 from dbtsl.timeout import TimeoutOptions
 
 TTransport = TypeVar("TTransport", Transport, AsyncTransport)
@@ -103,6 +104,18 @@ class BaseGraphQLClient(Generic[TTransport, TSession]):
             return AuthError(err.args)
 
         return err
+
+    def _attach_self_to_parsed_response(self, resp: object) -> None:
+        # NOTE: we're setting the _client_unchecked here instead of making a public property
+        # because we don't want end-users to be aware of this. You can consider _client_unchecked
+        # as public to the module but not to end users
+        if isinstance(resp, GraphQLFragmentMixin):
+            resp._client_unchecked = self  # type: ignore
+            return
+
+        if isinstance(resp, list):
+            for v in resp:  # pyright: ignore[reportUnknownVariableType]
+                v._client_unchecked = self
 
     @property
     def _gql_session(self) -> TSession:

--- a/dbtsl/api/graphql/client/base.py
+++ b/dbtsl/api/graphql/client/base.py
@@ -115,7 +115,7 @@ class BaseGraphQLClient(Generic[TTransport, TSession]):
 
         if isinstance(resp, list):
             for v in resp:  # pyright: ignore[reportUnknownVariableType]
-                v._client_unchecked = self
+                self._attach_self_to_parsed_response(v)  # pyright: ignore[reportUnknownArgumentType]
 
     @property
     def _gql_session(self) -> TSession:

--- a/dbtsl/api/graphql/client/base.py
+++ b/dbtsl/api/graphql/client/base.py
@@ -59,8 +59,11 @@ class BaseGraphQLClient(Generic[TTransport, TSession]):
         auth_token: str,
         url_format: Optional[str] = None,
         timeout: Optional[Union[TimeoutOptions, float, int]] = None,
+        *,
+        lazy: bool,
     ):
         self.environment_id = environment_id
+        self.lazy = lazy
 
         url_format = url_format or self.DEFAULT_URL_FORMAT
         server_url = url_format.format(server_host=server_host)
@@ -145,6 +148,8 @@ class GraphQLClientFactory(Protocol, Generic[TClient]):  # noqa: D101
         auth_token: str,
         url_format: Optional[str] = None,
         timeout: Optional[Union[TimeoutOptions, float, int]] = None,
+        *,
+        lazy: bool,
     ) -> TClient:
         """Initialize the Semantic Layer client.
 
@@ -154,5 +159,6 @@ class GraphQLClientFactory(Protocol, Generic[TClient]):  # noqa: D101
             auth_token: the API auth token
             url_format: the URL format string to construct the final URL with
             timeout: `TimeoutOptions` or total timeout
+            lazy: lazy load large fields
         """
         pass

--- a/dbtsl/api/graphql/client/sync.py
+++ b/dbtsl/api/graphql/client/sync.py
@@ -38,6 +38,8 @@ class SyncGraphQLClient(BaseGraphQLClient[RequestsHTTPTransport, SyncClientSessi
         auth_token: str,
         url_format: Optional[str] = None,
         timeout: Optional[Union[TimeoutOptions, float, int]] = None,
+        *,
+        lazy: bool,
     ):
         """Initialize the metadata client.
 
@@ -49,11 +51,12 @@ class SyncGraphQLClient(BaseGraphQLClient[RequestsHTTPTransport, SyncClientSessi
                 into a full URL. If `None`, the default `https://{server_host}/api/graphql`
                 will be assumed.
             timeout: TimeoutOptions or total timeout (in seconds) for all GraphQL requests.
+            lazy: Whether to lazy load large subfields
 
         NOTE: If `timeout` is a `TimeoutOptions`, the `tls_close_timeout` will not be used, since
         `requests` does not support TLS termination timeouts.
         """
-        super().__init__(server_host, environment_id, auth_token, url_format, timeout)
+        super().__init__(server_host, environment_id, auth_token, url_format, timeout, lazy=lazy)
 
     @override
     def _create_transport(self, url: str, headers: Dict[str, str]) -> RequestsHTTPTransport:
@@ -85,7 +88,7 @@ class SyncGraphQLClient(BaseGraphQLClient[RequestsHTTPTransport, SyncClientSessi
 
     def _run(self, op: ProtocolOperation[TVariables, TResponse], raw_variables: TVariables) -> TResponse:
         """Run a `ProtocolOperation`."""
-        raw_query = op.get_request_text()
+        raw_query = op.get_request_text(lazy=self.lazy)
         variables = op.get_request_variables(environment_id=self.environment_id, variables=raw_variables)
         gql_query = gql(raw_query)
 

--- a/dbtsl/api/graphql/client/sync.py
+++ b/dbtsl/api/graphql/client/sync.py
@@ -101,8 +101,9 @@ class SyncGraphQLClient(BaseGraphQLClient[RequestsHTTPTransport, SyncClientSessi
         except Exception as err:
             raise self._refine_err(err)
 
-        res["_client"] = self
-        return op.parse_response(res)
+        resp = op.parse_response(res)
+        self._attach_self_to_parsed_response(resp)
+        return resp
 
     def _poll_until_complete(
         self,

--- a/dbtsl/api/graphql/client/sync.py
+++ b/dbtsl/api/graphql/client/sync.py
@@ -101,6 +101,7 @@ class SyncGraphQLClient(BaseGraphQLClient[RequestsHTTPTransport, SyncClientSessi
         except Exception as err:
             raise self._refine_err(err)
 
+        res["_client"] = self
         return op.parse_response(res)
 
     def _poll_until_complete(

--- a/dbtsl/api/graphql/client/sync.pyi
+++ b/dbtsl/api/graphql/client/sync.pyi
@@ -11,8 +11,8 @@ from dbtsl.models import (
     Dimension,
     Entity,
     Measure,
-    Metric,
     SavedQuery,
+    SyncMetric,
 )
 from dbtsl.timeout import TimeoutOptions
 
@@ -30,7 +30,7 @@ class SyncGraphQLClient:
     def session(self) -> AbstractContextManager[Iterator[Self]]: ...
     @property
     def has_session(self) -> bool: ...
-    def metrics(self) -> List[Metric]:
+    def metrics(self) -> List[SyncMetric]:
         """Get a list of all available metrics."""
         ...
 

--- a/dbtsl/api/graphql/client/sync.pyi
+++ b/dbtsl/api/graphql/client/sync.pyi
@@ -24,6 +24,8 @@ class SyncGraphQLClient:
         auth_token: str,
         url_format: Optional[str] = None,
         timeout: Optional[Union[TimeoutOptions, float, int]] = None,
+        *,
+        lazy: bool,
     ) -> None: ...
     def session(self) -> AbstractContextManager[Iterator[Self]]: ...
     @property

--- a/dbtsl/api/graphql/protocol.py
+++ b/dbtsl/api/graphql/protocol.py
@@ -46,7 +46,7 @@ class ProtocolOperation(Generic[TVariables, TResponse], ABC):
     """Base class for GraphQL API operations."""
 
     @abstractmethod
-    def get_request_text(self) -> str:
+    def get_request_text(self, *, lazy: bool) -> str:
         """Get the GraphQL request text."""
         raise NotImplementedError()
 
@@ -71,7 +71,7 @@ class ListMetricsOperation(ProtocolOperation[EmptyVariables, List[Metric]]):
     """List all available metrics in available in the Semantic Layer."""
 
     @override
-    def get_request_text(self) -> str:
+    def get_request_text(self, *, lazy: bool) -> str:
         query = """
         query getMetrics($environmentId: BigInt!) {
             metrics(environmentId: $environmentId) {
@@ -79,7 +79,7 @@ class ListMetricsOperation(ProtocolOperation[EmptyVariables, List[Metric]]):
             }
         }
         """
-        return render_query(query, Metric.gql_fragments())
+        return render_query(query, Metric.gql_fragments(lazy=lazy))
 
     @override
     def get_request_variables(self, environment_id: int, variables: EmptyVariables) -> Dict[str, Any]:
@@ -100,7 +100,7 @@ class ListDimensionsOperation(ProtocolOperation[ListEntitiesOperationVariables, 
     """List all dimensions for a given set of metrics."""
 
     @override
-    def get_request_text(self) -> str:
+    def get_request_text(self, *, lazy: bool) -> str:
         query = """
         query getDimensions($environmentId: BigInt!, $metrics: [MetricInput!]!) {
             dimensions(environmentId: $environmentId, metrics: $metrics) {
@@ -108,7 +108,7 @@ class ListDimensionsOperation(ProtocolOperation[ListEntitiesOperationVariables, 
             }
         }
         """
-        return render_query(query, Dimension.gql_fragments())
+        return render_query(query, Dimension.gql_fragments(lazy=lazy))
 
     @override
     def get_request_variables(self, environment_id: int, variables: ListEntitiesOperationVariables) -> Dict[str, Any]:
@@ -126,7 +126,7 @@ class ListMeasuresOperation(ProtocolOperation[ListEntitiesOperationVariables, Li
     """List all measures for a given set of metrics."""
 
     @override
-    def get_request_text(self) -> str:
+    def get_request_text(self, *, lazy: bool) -> str:
         query = """
         query getMeasures($environmentId: BigInt!, $metrics: [MetricInput!]!) {
             measures(environmentId: $environmentId, metrics: $metrics) {
@@ -134,7 +134,7 @@ class ListMeasuresOperation(ProtocolOperation[ListEntitiesOperationVariables, Li
             }
         }
         """
-        return render_query(query, Measure.gql_fragments())
+        return render_query(query, Measure.gql_fragments(lazy=lazy))
 
     @override
     def get_request_variables(self, environment_id: int, variables: ListEntitiesOperationVariables) -> Dict[str, Any]:
@@ -152,7 +152,7 @@ class ListEntitiesOperation(ProtocolOperation[ListEntitiesOperationVariables, Li
     """List all entities for a given set of metrics."""
 
     @override
-    def get_request_text(self) -> str:
+    def get_request_text(self, *, lazy: bool) -> str:
         query = """
         query getEntities($environmentId: BigInt!, $metrics: [MetricInput!]!) {
             entities(environmentId: $environmentId, metrics: $metrics) {
@@ -160,7 +160,7 @@ class ListEntitiesOperation(ProtocolOperation[ListEntitiesOperationVariables, Li
             }
         }
         """
-        return render_query(query, Entity.gql_fragments())
+        return render_query(query, Entity.gql_fragments(lazy=lazy))
 
     @override
     def get_request_variables(self, environment_id: int, variables: ListEntitiesOperationVariables) -> Dict[str, Any]:
@@ -178,7 +178,7 @@ class ListSavedQueriesOperation(ProtocolOperation[EmptyVariables, List[SavedQuer
     """List all saved queries."""
 
     @override
-    def get_request_text(self) -> str:
+    def get_request_text(self, *, lazy: bool) -> str:
         query = """
         query getSavedQueries($environmentId: BigInt!) {
             savedQueries(environmentId: $environmentId) {
@@ -186,7 +186,7 @@ class ListSavedQueriesOperation(ProtocolOperation[EmptyVariables, List[SavedQuer
             }
         }
         """
-        return render_query(query, SavedQuery.gql_fragments())
+        return render_query(query, SavedQuery.gql_fragments(lazy=lazy))
 
     @override
     def get_request_variables(self, environment_id: int, variables: EmptyVariables) -> Dict[str, Any]:
@@ -242,7 +242,7 @@ class CreateQueryOperation(ProtocolOperation[QueryParameters, QueryId]):
     """Create a query that will be processed asynchronously."""
 
     @override
-    def get_request_text(self) -> str:
+    def get_request_text(self, *, lazy: bool) -> str:
         query = """
         mutation createQuery(
             $environmentId: BigInt!,
@@ -290,7 +290,7 @@ class GetQueryResultOperation(ProtocolOperation[GetQueryResultVariables, QueryRe
     """Get the results of a query that was already created."""
 
     @override
-    def get_request_text(self) -> str:
+    def get_request_text(self, *, lazy: bool) -> str:
         query = """
         query getQueryResults(
             $environmentId: BigInt!,
@@ -302,7 +302,7 @@ class GetQueryResultOperation(ProtocolOperation[GetQueryResultVariables, QueryRe
             }
         }
         """
-        return render_query(query, QueryResult.gql_fragments())
+        return render_query(query, QueryResult.gql_fragments(lazy=lazy))
 
     @override
     def get_request_variables(self, environment_id: int, variables: GetQueryResultVariables) -> Dict[str, Any]:
@@ -321,7 +321,7 @@ class CompileSqlOperation(ProtocolOperation[QueryParameters, str]):
     """Get the compiled SQL that would be sent to the warehouse by a query."""
 
     @override
-    def get_request_text(self) -> str:
+    def get_request_text(self, *, lazy: bool) -> str:
         query = """
         mutation compileSql(
             $environmentId: BigInt!,

--- a/dbtsl/client/asyncio.py
+++ b/dbtsl/client/asyncio.py
@@ -26,6 +26,8 @@ class AsyncSemanticLayerClient(BaseSemanticLayerClient[AsyncGraphQLClient, Async
         auth_token: str,
         host: str,
         timeout: Optional[Union[TimeoutOptions, float, int]] = None,
+        *,
+        lazy: bool = False,
     ) -> None:
         """Initialize the Semantic Layer client.
 
@@ -34,6 +36,7 @@ class AsyncSemanticLayerClient(BaseSemanticLayerClient[AsyncGraphQLClient, Async
             auth_token: the API auth token
             host: the Semantic Layer API host
             timeout: `TimeoutOptions` or total timeout for the underlying GraphQL client.
+            lazy: if true, nested metadata queries will be need to be explicitly populated on-demand.
         """
         super().__init__(
             environment_id=environment_id,
@@ -42,6 +45,7 @@ class AsyncSemanticLayerClient(BaseSemanticLayerClient[AsyncGraphQLClient, Async
             gql_factory=AsyncGraphQLClient,
             adbc_factory=AsyncADBCClient,
             timeout=timeout,
+            lazy=lazy,
         )
 
     @asynccontextmanager

--- a/dbtsl/client/asyncio.pyi
+++ b/dbtsl/client/asyncio.pyi
@@ -17,7 +17,17 @@ class AsyncSemanticLayerClient:
         auth_token: str,
         host: str,
         timeout: Optional[Union[TimeoutOptions, float, int]] = None,
+        *,
+        lazy: bool = False,
     ) -> None: ...
+    @property
+    def lazy(self) -> bool:
+        """Whether metadata queries will be lazy or not."""
+        ...
+    @lazy.setter
+    def lazy(self, v: bool) -> None:
+        """Set whether metadata queries will be lazy."""
+        ...
     @overload
     async def compile_sql(
         self,

--- a/dbtsl/client/asyncio.pyi
+++ b/dbtsl/client/asyncio.pyi
@@ -7,7 +7,7 @@ import pyarrow as pa
 from typing_extensions import Self, Unpack, overload
 
 from dbtsl.api.shared.query_params import GroupByParam, OrderByGroupBy, OrderByMetric, QueryParameters
-from dbtsl.models import Dimension, Entity, Measure, Metric, SavedQuery
+from dbtsl.models import AsyncMetric, Dimension, Entity, Measure, SavedQuery
 from dbtsl.timeout import TimeoutOptions
 
 class AsyncSemanticLayerClient:
@@ -92,7 +92,7 @@ class AsyncSemanticLayerClient:
         """Query the Semantic Layer."""
         ...
 
-    async def metrics(self) -> List[Metric]:
+    async def metrics(self) -> List[AsyncMetric]:
         """List all the metrics available in the Semantic Layer."""
         ...
 

--- a/dbtsl/client/base.py
+++ b/dbtsl/client/base.py
@@ -41,6 +41,8 @@ class BaseSemanticLayerClient(ABC, Generic[TGQLClient, TADBCClient]):
         gql_factory: GraphQLClientFactory[TGQLClient],
         adbc_factory: ADBCClientFactory[TADBCClient],
         timeout: Optional[Union[TimeoutOptions, float, int]] = None,
+        *,
+        lazy: bool,
     ) -> None:
         """Initialize the Semantic Layer client.
 
@@ -51,6 +53,7 @@ class BaseSemanticLayerClient(ABC, Generic[TGQLClient, TADBCClient]):
             gql_factory: class of the underlying GQL client
             adbc_factory: class of the underlying ADBC client
             timeout: `TimeoutOptions` or total timeout for the underlying GraphQL client.
+            lazy: `lazy` for the underlying GraphQL client
         """
         self._has_session = False
 
@@ -62,6 +65,7 @@ class BaseSemanticLayerClient(ABC, Generic[TGQLClient, TADBCClient]):
             auth_token=auth_token,
             url_format=env.GRAPHQL_URL_FORMAT,
             timeout=timeout,
+            lazy=lazy,
         )
         self._adbc = adbc_factory(
             server_host=host,
@@ -69,6 +73,16 @@ class BaseSemanticLayerClient(ABC, Generic[TGQLClient, TADBCClient]):
             auth_token=auth_token,
             url_format=env.ADBC_URL_FORMAT,
         )
+
+    @property
+    def lazy(self) -> bool:
+        """Whether metadata queries will be lazy or not."""
+        return self._gql.lazy
+
+    @lazy.setter
+    def lazy(self, v: bool) -> None:
+        """Set whether metadata queries will be lazy."""
+        self._gql.lazy = v
 
     def __getattr__(self, attr: str) -> Any:
         """Get methods from the underlying APIs.

--- a/dbtsl/client/sync.py
+++ b/dbtsl/client/sync.py
@@ -26,6 +26,8 @@ class SyncSemanticLayerClient(BaseSemanticLayerClient[SyncGraphQLClient, SyncADB
         auth_token: str,
         host: str,
         timeout: Optional[Union[TimeoutOptions, float, int]] = None,
+        *,
+        lazy: bool = False,
     ) -> None:
         """Initialize the Semantic Layer client.
 
@@ -34,6 +36,7 @@ class SyncSemanticLayerClient(BaseSemanticLayerClient[SyncGraphQLClient, SyncADB
             auth_token: the API auth token
             host: the Semantic Layer API host
             timeout: `TimeoutOptions` or total timeout for the underlying GraphQL client.
+            lazy: if true, nested metadata queries will be need to be explicitly populated on-demand.
         """
         super().__init__(
             environment_id=environment_id,
@@ -42,6 +45,7 @@ class SyncSemanticLayerClient(BaseSemanticLayerClient[SyncGraphQLClient, SyncADB
             gql_factory=SyncGraphQLClient,
             adbc_factory=SyncADBCClient,
             timeout=timeout,
+            lazy=lazy,
         )
 
     @contextmanager

--- a/dbtsl/client/sync.pyi
+++ b/dbtsl/client/sync.pyi
@@ -7,7 +7,7 @@ import pyarrow as pa
 from typing_extensions import Self, Unpack, overload
 
 from dbtsl.api.shared.query_params import GroupByParam, OrderByGroupBy, OrderByMetric, QueryParameters
-from dbtsl.models import Dimension, Entity, Measure, Metric, SavedQuery
+from dbtsl.models import Dimension, Entity, Measure, SavedQuery, SyncMetric
 from dbtsl.timeout import TimeoutOptions
 
 class SyncSemanticLayerClient:
@@ -91,7 +91,7 @@ class SyncSemanticLayerClient:
         """Query the Semantic Layer."""
         ...
 
-    def metrics(self) -> List[Metric]:
+    def metrics(self) -> List[SyncMetric]:
         """List all the metrics available in the Semantic Layer."""
         ...
 

--- a/dbtsl/client/sync.pyi
+++ b/dbtsl/client/sync.pyi
@@ -17,7 +17,16 @@ class SyncSemanticLayerClient:
         auth_token: str,
         host: str,
         timeout: Optional[Union[TimeoutOptions, float, int]] = None,
+        lazy: bool = False,
     ) -> None: ...
+    @property
+    def lazy(self) -> bool:
+        """Whether metadata queries will be lazy or not."""
+        ...
+    @lazy.setter
+    def lazy(self, v: bool) -> None:
+        """Set whether metadata queries will be lazy."""
+        ...
     @overload
     def compile_sql(
         self,

--- a/dbtsl/models/__init__.py
+++ b/dbtsl/models/__init__.py
@@ -4,11 +4,11 @@ NOTE: this will be deleted in the future and will be replaced by
 generated code from our GraphQL schema.
 """
 
-from .base import BaseModel
+from .base import BaseModel, GraphQLFragmentMixin
 from .dimension import Dimension, DimensionType
 from .entity import Entity, EntityType
 from .measure import AggregationType, Measure
-from .metric import Metric, MetricType
+from .metric import AsyncMetric, Metric, MetricType, SyncMetric
 from .query import QueryResult
 from .saved_query import (
     Export,
@@ -26,9 +26,11 @@ from .time import DatePart, TimeGranularity
 _ = QueryResult
 
 BaseModel._register_subclasses()  # pyright: ignore[reportPrivateUsage]
+GraphQLFragmentMixin._register_subclasses()  # pyright: ignore[reportPrivateUsage]
 
 __all__ = [
     "AggregationType",
+    "AsyncMetric",
     "DatePart",
     "Dimension",
     "DimensionType",
@@ -46,5 +48,6 @@ __all__ = [
     "SavedQueryMetricParam",
     "SavedQueryQueryParams",
     "SavedQueryWhereParam",
+    "SyncMetric",
     "TimeGranularity",
 ]

--- a/dbtsl/models/base.py
+++ b/dbtsl/models/base.py
@@ -1,12 +1,14 @@
 import inspect
 import typing
 import warnings
+from asyncio.tasks import Task
+from collections.abc import Awaitable
 from dataclasses import dataclass, fields, is_dataclass
 from dataclasses import field as dc_field
 from enum import EnumMeta
 from functools import cache
 from types import MappingProxyType
-from typing import Any, ClassVar, Dict, List, Set, Tuple, Type, Union
+from typing import Any, ClassVar, Dict, List, Optional, Set, Tuple, Type, Union
 from typing import get_args as get_type_args
 from typing import get_origin as get_type_origin
 
@@ -16,7 +18,8 @@ from mashumaro.config import BaseConfig
 from dbtsl.api.graphql.util import normalize_query
 
 if typing.TYPE_CHECKING:
-    from dbtsl.api.graphql.client.base import BaseGraphQLClient
+    from dbtsl.api.graphql.client.asyncio import AsyncGraphQLClient
+    from dbtsl.api.graphql.client.sync import SyncGraphQLClient
 
 
 def snake_case_to_camel_case(s: str) -> str:
@@ -137,23 +140,82 @@ class GraphQLFragment:
     lazy: bool
 
 
-@dataclass
 class GraphQLFragmentMixin:
     """Add this to any model that needs to be fetched from GraphQL."""
 
     # mark fields that should not be lazy with this
     NOT_LAZY: ClassVar[str] = "dbtsl_notlazy"
 
-    _subclass_registry: ClassVar[Set[Type["GraphQLFragmentMixin"]]] = set()
+    # set of all field names that are lazy loadable
+    _lazy_loadable_fields: ClassVar[Set[str]]
 
-    _client: "BaseGraphQLClient[Any, Any]"
+    def __init__(self) -> None:
+        """Init the unchecked client as None."""
+        self._client_unchecked: Optional[Union["SyncGraphQLClient", "AsyncGraphQLClient"]] = None
 
-    def __init_subclass__(cls) -> None:
-        """Add subclasses to the subclass registry.
+    @property
+    def _client(self) -> Union["SyncGraphQLClient", "AsyncGraphQLClient"]:
+        assert self._client_unchecked is not None
+        return self._client_unchecked
 
-        This registry is used by some tests.
+    @staticmethod
+    def _make_field_loader(field: str) -> Union[Any, Task[Any]]:
+        """Returns an IO-agnostic wrapped method that loads a field and sets its property in the model.
+
+        This wrapper will call an underlying private `_load_{field}` which will actually hold the
+        implementation of the loader.
+
+        The reason this exists is to make underlying loaders independent of sync and async IO.
         """
-        GraphQLFragmentMixin._subclass_registry.add(cls)
+
+        def _loader(self: GraphQLFragmentMixin) -> Union[Any, Awaitable[Any]]:
+            load_field_method = getattr(self, f"_load_{field}")
+
+            coro_or_result = load_field_method()
+
+            # async
+            if inspect.iscoroutine(coro_or_result):
+
+                async def set_field_async(coro: Awaitable[Any]) -> Any:
+                    result = await coro
+                    setattr(self, field, result)
+                    return result
+
+                return set_field_async(coro_or_result)
+
+            # sync
+            setattr(self, field, coro_or_result)
+            return coro_or_result
+
+        return _loader
+
+    @classmethod
+    def _register_subclasses(cls) -> None:
+        """Process fields of all subclasses.
+
+        This will populate the _lazy_loadable_fields set for each subclass
+        """
+        for subclass in cls.__subclasses__():
+            subclass._lazy_loadable_fields = set()
+            assert is_dataclass(subclass)
+            for field in fields(subclass):
+                if GraphQLFragmentMixin.NOT_LAZY in field.metadata:
+                    continue
+
+                type_origin = get_type_origin(field.type)
+                if type_origin is None:
+                    continue
+                # We know it's a List[...], Union[...] or Optional[...]
+
+                inner_type = get_type_args(field.type)[0]
+                if inspect.isclass(inner_type) and issubclass(inner_type, GraphQLFragmentMixin):
+                    # We know it's either:
+                    # - List[GraphQLFragmentMixin]
+                    # - Union[GraphQLFragmentMixin]
+                    # - Optional[GraphQLFragmentMixin]
+                    subclass._lazy_loadable_fields.add(field.name)
+
+                setattr(subclass, f"load_{field.name}", GraphQLFragmentMixin._make_field_loader(field.name))
 
     @classmethod
     def gql_model_name(cls) -> str:
@@ -165,36 +227,30 @@ class GraphQLFragmentMixin:
     #
     # If we do that, we need to modify this method to memoize what fragments were already created
     # so that we exit the recursion gracefully
-    @staticmethod
+    @classmethod
     def _get_fragments_for_field(
+        cls,
         type: Union[Type[Any], str],
         field_name: str,
         *,
-        field_lazy: bool,
-        global_lazy: bool,
+        lazy: bool,
     ) -> Union[str, List[GraphQLFragment], None]:
+        if lazy and field_name in cls._lazy_loadable_fields:
+            return None
+
         # field is a GraphQLFragmentMixin
         if inspect.isclass(type) and issubclass(type, GraphQLFragmentMixin):
-            return type.gql_fragments(lazy=global_lazy)
+            return type.gql_fragments(lazy=lazy)
 
         # field is an Optional, Union or List
         type_origin = get_type_origin(type)
         if type_origin is list or type_origin is Union:
             inner_type = get_type_args(type)[0]
 
-            if (
-                global_lazy
-                and field_lazy
-                and inspect.isclass(inner_type)
-                and issubclass(inner_type, GraphQLFragmentMixin)
-            ):
-                return None
-
-            return GraphQLFragmentMixin._get_fragments_for_field(
+            return cls._get_fragments_for_field(
                 inner_type,
                 field_name,
-                field_lazy=field_lazy,
-                global_lazy=global_lazy,
+                lazy=lazy,
             )
 
         return snake_case_to_camel_case(field_name)
@@ -221,25 +277,20 @@ class GraphQLFragmentMixin:
         query_elements: List[str] = []
         dependencies: Set[GraphQLFragment] = set()
         for field in fields(cls):
-            if field.name == "_client":
-                continue
-
-            field_lazy = lazy and GraphQLFragmentMixin.NOT_LAZY not in field.metadata
-            frag_or_field = GraphQLFragmentMixin._get_fragments_for_field(
+            frag_or_field = cls._get_fragments_for_field(
                 field.type,
                 field.name,
-                field_lazy=field_lazy,
-                global_lazy=lazy,
+                lazy=lazy,
             )
-            if isinstance(frag_or_field, str):
+            if frag_or_field is None:
+                assert lazy
+            elif isinstance(frag_or_field, str):
                 query_elements.append(frag_or_field)
-            elif frag_or_field is not None:
+            else:
                 frag = frag_or_field[0]
                 field_query = snake_case_to_camel_case(field.name) + " { ..." + frag.name + " }"
                 query_elements.append(field_query)
                 dependencies.update(frag_or_field)
-            else:
-                assert lazy
 
         query_str = "         \n".join(query_elements)
 

--- a/dbtsl/models/dimension.py
+++ b/dbtsl/models/dimension.py
@@ -20,7 +20,7 @@ QUERYABLE_GRANULARITIES_DEPRECATION = (
 )
 
 
-@dataclass(frozen=True)
+@dataclass
 class Dimension(BaseModel, GraphQLFragmentMixin):
     """A metric dimension."""
 

--- a/dbtsl/models/entity.py
+++ b/dbtsl/models/entity.py
@@ -15,7 +15,7 @@ class EntityType(Enum, metaclass=FlexibleEnumMeta):
     UNIQUE = "UNIQUE"
 
 
-@dataclass(frozen=True)
+@dataclass
 class Entity(BaseModel, GraphQLFragmentMixin):
     """An entity."""
 

--- a/dbtsl/models/measure.py
+++ b/dbtsl/models/measure.py
@@ -20,7 +20,7 @@ class AggregationType(Enum, metaclass=FlexibleEnumMeta):
     COUNT = "COUNT"
 
 
-@dataclass(frozen=True)
+@dataclass
 class Measure(BaseModel, GraphQLFragmentMixin):
     """A measure."""
 

--- a/dbtsl/models/metric.py
+++ b/dbtsl/models/metric.py
@@ -27,7 +27,7 @@ QUERYABLE_GRANULARITIES_DEPRECATION = (
 )
 
 
-@dataclass(frozen=True)
+@dataclass
 class Metric(BaseModel, GraphQLFragmentMixin):
     """A metric."""
 

--- a/dbtsl/models/metric.py
+++ b/dbtsl/models/metric.py
@@ -1,6 +1,7 @@
+from abc import ABC
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Optional
+from typing import Awaitable, List, Optional, Union
 
 from dbtsl.models.base import NOT_LAZY_META as NOT_LAZY
 from dbtsl.models.base import BaseModel, FlexibleEnumMeta, GraphQLFragmentMixin
@@ -46,3 +47,50 @@ class Metric(BaseModel, GraphQLFragmentMixin):
     dimensions: List[Dimension] = field(default_factory=list)
     measures: List[Measure] = field(default_factory=list)
     entities: List[Entity] = field(default_factory=list)
+
+    def _load_dimensions(self) -> Union[List[Dimension], Awaitable[List[Dimension]]]:
+        return self._client.dimensions(metrics=[self.name])
+
+    def _load_measures(self) -> Union[List[Measure], Awaitable[List[Measure]]]:
+        return self._client.measures(metrics=[self.name])
+
+    def _load_entities(self) -> Union[List[Entity], Awaitable[List[Entity]]]:
+        return self._client.entities(metrics=[self.name])
+
+
+class SyncMetric(Metric, ABC):
+    """A metric with type annotations for sync lazy loading methods.
+
+    At runtime this is just a regular Metric. Don't use this directly.
+    """
+
+    def load_dimensions(self) -> List[Dimension]:
+        """Lazy load dimensions for this metric."""
+        raise NotImplementedError()
+
+    def load_measures(self) -> List[Measure]:
+        """Lazy load measures for this metric."""
+        raise NotImplementedError()
+
+    def load_entities(self) -> List[Entity]:
+        """Lazy load entities for this metric."""
+        raise NotImplementedError()
+
+
+class AsyncMetric(Metric, ABC):
+    """A metric with type annotations for async lazy loading methods.
+
+    At runtime this is just a regular Metric. Don't use this directly.
+    """
+
+    async def load_dimensions(self) -> List[Dimension]:
+        """Lazy load dimensions for this metric."""
+        raise NotImplementedError()
+
+    async def load_measures(self) -> List[Measure]:
+        """Lazy load measures for this metric."""
+        raise NotImplementedError()
+
+    async def load_entities(self) -> List[Entity]:
+        """Lazy load entities for this metric."""
+        raise NotImplementedError()

--- a/dbtsl/models/metric.py
+++ b/dbtsl/models/metric.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import List, Optional
 
+from dbtsl.models.base import NOT_LAZY_META as NOT_LAZY
 from dbtsl.models.base import BaseModel, FlexibleEnumMeta, GraphQLFragmentMixin
 from dbtsl.models.dimension import Dimension
 from dbtsl.models.entity import Entity
@@ -33,12 +34,15 @@ class Metric(BaseModel, GraphQLFragmentMixin):
     name: str
     description: Optional[str]
     type: MetricType
-    dimensions: List[Dimension]
-    measures: List[Measure]
-    entities: List[Entity]
     queryable_granularities: List[TimeGranularity] = field(
-        metadata={BaseModel.DEPRECATED: QUERYABLE_GRANULARITIES_DEPRECATION}
+        metadata={
+            BaseModel.DEPRECATED: QUERYABLE_GRANULARITIES_DEPRECATION,
+        }
     )
-    queryable_time_granularities: List[str]
+    queryable_time_granularities: List[str] = field(metadata=NOT_LAZY)
     label: str
     requires_metric_time: bool
+
+    dimensions: List[Dimension] = field(default_factory=list)
+    measures: List[Measure] = field(default_factory=list)
+    entities: List[Entity] = field(default_factory=list)

--- a/dbtsl/models/query.py
+++ b/dbtsl/models/query.py
@@ -22,7 +22,7 @@ class QueryStatus(Enum, metaclass=FlexibleEnumMeta):
     FAILED = "FAILED"
 
 
-@dataclass(frozen=True)
+@dataclass
 class QueryResult(BaseModel, GraphQLFragmentMixin):
     """A query result containing its status, SQL and error/results."""
 

--- a/dbtsl/models/saved_query.py
+++ b/dbtsl/models/saved_query.py
@@ -3,6 +3,7 @@ from dataclasses import field as dc_field
 from enum import Enum
 from typing import List, Optional
 
+from dbtsl.models.base import NOT_LAZY_META as NOT_LAZY
 from dbtsl.models.base import BaseModel, FlexibleEnumMeta, GraphQLFragmentMixin
 from dbtsl.models.time import DatePart, TimeGranularity
 
@@ -70,9 +71,9 @@ class SavedQueryWhereParam(BaseModel, GraphQLFragmentMixin):
 class SavedQueryQueryParams(BaseModel, GraphQLFragmentMixin):
     """The parameters of a saved query."""
 
-    metrics: List[SavedQueryMetricParam]
-    group_by: List[SavedQueryGroupByParam]
-    where: Optional[SavedQueryWhereParam]
+    metrics: List[SavedQueryMetricParam] = dc_field(metadata=NOT_LAZY)
+    group_by: List[SavedQueryGroupByParam] = dc_field(metadata=NOT_LAZY)
+    where: Optional[SavedQueryWhereParam] = dc_field(metadata=NOT_LAZY)
 
 
 @dataclass(frozen=True)
@@ -83,4 +84,4 @@ class SavedQuery(BaseModel, GraphQLFragmentMixin):
     description: Optional[str]
     label: Optional[str]
     query_params: SavedQueryQueryParams
-    exports: List[Export]
+    exports: List[Export] = dc_field(metadata=NOT_LAZY)

--- a/dbtsl/models/saved_query.py
+++ b/dbtsl/models/saved_query.py
@@ -16,7 +16,7 @@ class ExportDestinationType(Enum, metaclass=FlexibleEnumMeta):
     VIEW = "VIEW"
 
 
-@dataclass(frozen=True)
+@dataclass
 class ExportConfig(BaseModel, GraphQLFragmentMixin):
     """A saved query export config."""
 
@@ -25,7 +25,7 @@ class ExportConfig(BaseModel, GraphQLFragmentMixin):
     export_as: ExportDestinationType
 
 
-@dataclass(frozen=True)
+@dataclass
 class Export(BaseModel, GraphQLFragmentMixin):
     """A saved query export."""
 
@@ -33,7 +33,7 @@ class Export(BaseModel, GraphQLFragmentMixin):
     config: ExportConfig
 
 
-@dataclass(frozen=True)
+@dataclass
 class SavedQueryMetricParam(BaseModel, GraphQLFragmentMixin):
     """The metric param of a saved query."""
 
@@ -46,7 +46,7 @@ GRAIN_DEPRECATION = (
 )
 
 
-@dataclass(frozen=True)
+@dataclass
 class SavedQueryGroupByParam(BaseModel, GraphQLFragmentMixin):
     """The groupBy param of a saved query."""
 
@@ -56,7 +56,7 @@ class SavedQueryGroupByParam(BaseModel, GraphQLFragmentMixin):
     date_part: Optional[DatePart]
 
 
-@dataclass(frozen=True)
+@dataclass
 class SavedQueryWhereParam(BaseModel, GraphQLFragmentMixin):
     """The where param of a saved query."""
 
@@ -67,7 +67,7 @@ class SavedQueryWhereParam(BaseModel, GraphQLFragmentMixin):
     where_sql_template: str
 
 
-@dataclass(frozen=True)
+@dataclass
 class SavedQueryQueryParams(BaseModel, GraphQLFragmentMixin):
     """The parameters of a saved query."""
 
@@ -76,7 +76,7 @@ class SavedQueryQueryParams(BaseModel, GraphQLFragmentMixin):
     where: Optional[SavedQueryWhereParam] = dc_field(metadata=NOT_LAZY)
 
 
-@dataclass(frozen=True)
+@dataclass
 class SavedQuery(BaseModel, GraphQLFragmentMixin):
     """A saved query."""
 

--- a/examples/list_metrics_lazy_sync.py
+++ b/examples/list_metrics_lazy_sync.py
@@ -1,4 +1,4 @@
-"""Lazily fetch all available metrics from the metadata API display only the dimensions of certain metrics."""
+"""Fetch all available metrics from the metadata API and display only the dimensions of certain metrics."""
 
 from argparse import ArgumentParser
 
@@ -40,7 +40,7 @@ def main() -> None:
                 print("     dimensions=skipped")
                 continue
 
-            # load dimensions only if even
+            # load dimensions only if index is even
             m.load_dimensions()
 
             print("     dimensions=[")

--- a/examples/list_metrics_lazy_sync.py
+++ b/examples/list_metrics_lazy_sync.py
@@ -1,0 +1,53 @@
+"""Lazily fetch all available metrics from the metadata API display only the dimensions of certain metrics."""
+
+from argparse import ArgumentParser
+
+from dbtsl import SemanticLayerClient
+
+
+def get_arg_parser() -> ArgumentParser:
+    p = ArgumentParser()
+
+    p.add_argument("--env-id", required=True, help="The dbt environment ID", type=int)
+    p.add_argument("--token", required=True, help="The API auth token")
+    p.add_argument("--host", required=True, help="The API host")
+
+    return p
+
+
+def main() -> None:
+    arg_parser = get_arg_parser()
+    args = arg_parser.parse_args()
+
+    client = SemanticLayerClient(
+        environment_id=args.env_id,
+        auth_token=args.token,
+        host=args.host,
+        lazy=True,
+    )
+
+    with client.session():
+        metrics = client.metrics()
+        for i, m in enumerate(metrics):
+            print(f"📈 {m.name}")
+            print(f"     type={m.type}")
+            print(f"     description={m.description}")
+
+            assert len(m.dimensions) == 0
+
+            # skip if index is odd
+            if i & 1:
+                print("     dimensions=skipped")
+                continue
+
+            # load dimensions only if even
+            m.load_dimensions()
+
+            print("     dimensions=[")
+            for dim in m.dimensions:
+                print(f"        {dim.name},")
+            print("     ]")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,19 +129,10 @@ asyncio_mode = "auto"
 
 [tool.pyright]
 typeCheckingMode = "strict"
-venv = ".venv/"
-
-[[tool.pyright.executionEnvironments]]
-root = "tests"
-# Tests use private methods and assign inappropriate values to some
-# properties to check our error handling capabilities etc. To avoid
-# having to ignore everything, we disable some checks
-reportPrivateUsage = false
-reportAssignmentType = false
-reportAny = false
-reportCallIssue = false
-reportArgumentType = false
-reportUnknownMemberType = false
+executionEnvironments = [
+  { root = "tests", extraPaths = ["."], reportPrivateUsage = false, reportAssignmentType = false, reportAny = false, reportCallIssue = false, reportArgumentType = false, reportUnknownMemberType = false },
+  { root = "." }
+]
 
 [tool.mypy]
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,8 +184,8 @@ known-first-party = ["dbtsl"]
 
 [tool.ruff.lint.per-file-ignores]
 # Ignore docs for test files
-"*_test.py" = ["D101", "D103"]
-"tests/**" = ["D101", "D103"]
+"*_test.py" = ["D101", "D102", "D103"]
+"tests/**" = ["D101", "D102", "D103"]
 
 # Ignore prints in examples
 "examples/**" = ["T201", "D103"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,8 +184,8 @@ known-first-party = ["dbtsl"]
 
 [tool.ruff.lint.per-file-ignores]
 # Ignore docs for test files
-"*_test.py" = ["D103"]
-"tests/**" = ["D103"]
+"*_test.py" = ["D101", "D103"]
+"tests/**" = ["D101", "D103"]
 
 # Ignore prints in examples
 "examples/**" = ["T201", "D103"]

--- a/tests/api/graphql/test_client.py
+++ b/tests/api/graphql/test_client.py
@@ -36,6 +36,7 @@ async def test_async_query_multiple_pages(mocker: MockerFixture) -> None:
             writer.write_table(call_table)
 
         return QueryResult(
+            _client=client,
             query_id=query_id,
             status=QueryStatus.SUCCESSFUL,
             sql=None,
@@ -101,6 +102,7 @@ def test_sync_query_multiple_pages(mocker: MockerFixture) -> None:
             writer.write_table(call_table)
 
         return QueryResult(
+            _client=client,
             query_id=query_id,
             status=QueryStatus.SUCCESSFUL,
             sql=None,

--- a/tests/api/graphql/test_client.py
+++ b/tests/api/graphql/test_client.py
@@ -20,7 +20,7 @@ from dbtsl.models.query import QueryId, QueryResult, QueryStatus
 
 async def test_async_query_multiple_pages(mocker: MockerFixture) -> None:
     """Test that querying a dataframe with multiple pages works."""
-    client = AsyncGraphQLClient(server_host="test", environment_id=0, auth_token="test")
+    client = AsyncGraphQLClient(server_host="test", environment_id=0, auth_token="test", lazy=False)
 
     query_id = QueryId("test-query-id")
     table = pa.Table.from_arrays(
@@ -85,7 +85,7 @@ async def test_async_query_multiple_pages(mocker: MockerFixture) -> None:
 @pytest.mark.filterwarnings("ignore::pytest_mock.PytestMockWarning")
 def test_sync_query_multiple_pages(mocker: MockerFixture) -> None:
     """Test that querying a dataframe with multiple pages works."""
-    client = SyncGraphQLClient(server_host="test", environment_id=0, auth_token="test")
+    client = SyncGraphQLClient(server_host="test", environment_id=0, auth_token="test", lazy=False)
 
     query_id = QueryId("test-query-id")
     table = pa.Table.from_arrays(

--- a/tests/api/graphql/test_client.py
+++ b/tests/api/graphql/test_client.py
@@ -36,7 +36,6 @@ async def test_async_query_multiple_pages(mocker: MockerFixture) -> None:
             writer.write_table(call_table)
 
         return QueryResult(
-            _client=client,
             query_id=query_id,
             status=QueryStatus.SUCCESSFUL,
             sql=None,
@@ -102,7 +101,6 @@ def test_sync_query_multiple_pages(mocker: MockerFixture) -> None:
             writer.write_table(call_table)
 
         return QueryResult(
-            _client=client,
             query_id=query_id,
             status=QueryStatus.SUCCESSFUL,
             sql=None,

--- a/tests/api/graphql/test_protocol.py
+++ b/tests/api/graphql/test_protocol.py
@@ -47,6 +47,6 @@ def test_queries_are_valid(test_case: TestCase, validate_query: QueryValidator) 
     op_name, raw_variables = test_case
 
     op = getattr(GraphQLProtocol, op_name)
-    query = op.get_request_text()
+    query = op.get_request_text(lazy=False)
     variable_values = op.get_request_variables(environment_id=123, variables=raw_variables)
     validate_query(query, variable_values)

--- a/tests/api/graphql/test_util.py
+++ b/tests/api/graphql/test_util.py
@@ -33,6 +33,7 @@ def test_render_query() -> None:
                 }
             }
             """,
+            lazy=False,
         ),
         GraphQLFragment(
             name="depFrag",
@@ -41,6 +42,7 @@ def test_render_query() -> None:
                 baz
             }
             """,
+            lazy=False,
         ),
     ]
 

--- a/tests/integration/test_sl_client.py
+++ b/tests/integration/test_sl_client.py
@@ -140,14 +140,7 @@ async def test_client_metadata_lazy(subtests: SubTests, client_lazy: BothClients
         client_entities = await maybe_await(client_lazy.entities(metrics=[metric.name]))
         assert model_list_equal(client_entities, model_entities)
 
-    with subtests.test("dimension_values"):
-        dimension = metric.dimensions[0]
-        dim_values = await maybe_await(client_lazy.dimension_values(metrics=[metric.name], group_by=dimension.name))
-        assert len(dim_values) > 0
-
-    with subtests.test("saved_queries"):
-        sqs = await maybe_await(client_lazy.saved_queries())
-        assert len(sqs) > 0
+    # NOTE: dimension_values and saved_queries are not lazy, so not testing it here
 
 
 @pytest.mark.parametrize("api", [ADBC, GRAPHQL])


### PR DESCRIPTION
## Summary

This PR introduces new functionality to allow models to lazy load certain large fields if users want to. This is only used in `Metric.dimensions`, `Metric.entities` and `Metric.measures` for now, but can easily be expanded to other fields in the future if we deem necessary.

There are no breaking changes.

## End-user API

This is what it looks like from an end user perspective:
```python
from dbtsl import SemanticLayerClient

def main():
    sl = SemanticLayerClient(..., lazy=True)
    with sl.session():
        metrics = sl.metrics()
        metric = metrics[0]
        assert metric.dimensions == []
        loaded = metric.load_dimensions()
        assert len(loaded) > 0
        assert loaded == metric.dimensions
        
main()
```

The `asyncio` equivalent is:
```python
import asyncio
from dbtsl.asyncio import AsyncSemanticLayerClient

async def main():
    sl = AsyncSemanticLayerClient(..., lazy=True)
    async with sl.session():
        metrics = await sl.metrics()
        metric = metrics[0]
        assert metric.dimensions == []
        loaded = await metric.load_dimensions()
        assert len(loaded) > 0
        assert loaded == metric.dimensions
        
asyncio.run(main())
```


## Base implementation

The bulk of the work happened in `base.py`, and `metric.py` uses the new functionality in the `Metric` model (more on that later). Other changes are tests and "plumbing" of the `lazy` paramater which needs to get passed around.

I added a `_lazy_loadable_fields` property that gets added to each subclass of `GraphQLModelMixin` on `GraphQLModelMixin._register_subclasses()`. When registering a new subclass, it will iterate over all fields in that subclass and determine whether the field is lazy-loadable. It makes that decision by:
- Checking if the field has `NOT_LAZY` in the metadata. If that's true, the field is not added to `_lazy_loadable_fields`.
- If the field is not `Optional[...]`, `Union[...]` or `List[...]`, then it's also considered not lazy-loadable.
- If the inner argument of the type annotation is also a `GraphQLModelMixin`, then it's considered lazy-loadable and is added to `_lazy_loadable_fields`.

This makes it possible for us to tag "light" fields as `NOT_LAZY` [1], like I did for saved queries. In that case, I believe it's better to just fetch everything at once to minimize round trip time. I did this mainly because otherwise it would be pretty annoying for the user in some cases where our API has multiple levels of nested objects like `saved_query.query_params.metrics.name`.

Then, I made a minor modification to `GraphQLModelMixin.gql_fragments()`, which now accepts a `lazy: bool` param. If `lazy=True`, it will omit lazy fields from the fragment definition.

Finally,`GraphQLModelMixin._register_subclasses()` will create `load_{field}()` methods in the object, which will wrap a `_load_{field_name}` method with a sync/async loader that will also set the field after the loader returns. These `_load_{field_name}` methods will be specific of each model implementation, which can now use `self._client` to make requests.

To test all this, I added some tests on `test_base.py` to make sure that the `_lazy_loadable_fields` property gets initialized properly for subclasses, and that the GraphQL fragments contain the expected GraphQL text and dependencies depending if we're using`lazy` or not. 

I also added some sanity check tests to assist developers in catching bad implementations in unit tests instead of having to wait for integration tests to fail with runtime errors. It ensures every lazy loadable field needs a default value (like an empty list, or `None` etc) and a corresponding `_load_{field}` method.

[1] It is perfectly valid to ask why I made the default be lazy, while `NOT_LAZY` is opt-in, and not the other way around. My rationale was that if we ever add new fields to the API, we want to autodetect if they are supposed to be lazy (i.e return a list), and make developers have to opt-out if they think it's unnecessary. This way we hopefully won't end up with slow fields in the future.

## `Metric` implementation

I made `dimensions`, `entities` and `measures` lazy. I had to create two new classes: `SyncMetric` and `AsyncMetric`, which are only for annotating the return type of `load_{field}` depending on the client. The sync clients return `SyncMetric` while the async clients return `AsyncMetric`. This is all for typing only, and at runtime everything is just regular `Metric`. I made both of these classes inherit from `ABC` to make sure users don't use them directly, and I added docs to warn them that they shouldn't.


## Integration testing

I added a new test for lazy loading dimensions, entities and measures of a metric in our integration test suite. The regular "eager" tests continue to work normally.


## Docs

I added a new example to `examples/`, and I added a new section to our README briefly explaining when/why to use lazy-loading.

