### PR TITLE
Fix TimeDimension in group_by

### DIFF
--- a/.changes/unreleased/Fixes-20250414-204039.yaml
+++ b/.changes/unreleased/Fixes-20250414-204039.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Fix TimeDimension in group_by
+time: 2025-04-14T20:40:39.754768-05:00

--- a/dbtsl/api/adbc/protocol.py
+++ b/dbtsl/api/adbc/protocol.py
@@ -46,6 +46,8 @@ class ADBCProtocol:
                 g = f'Dimension("{val.name}")'
             elif val.type == GroupByType.ENTITY:
                 g = f'Entity("{val.name}")'
+            else:  # val.type == GroupByType.TIME_DIMENSION
+                return f'TimeDimension("{val.name}", "{val.grain}")'
             if val.grain:
                 grain_str = val.grain.lower()
                 g += f'.grain("{grain_str}")'

--- a/dbtsl/api/shared/query_params.py
+++ b/dbtsl/api/shared/query_params.py
@@ -7,6 +7,7 @@ class GroupByType(Enum):
     """The type of a group_by, i.e a dimension or an entity."""
 
     DIMENSION = "dimension"
+    TIME_DIMENSION = "time_dimension"
     ENTITY = "entity"
 
 

--- a/tests/api/adbc/test_protocol.py
+++ b/tests/api/adbc/test_protocol.py
@@ -31,6 +31,21 @@ def test_serialize_val_OrderByGroupBy() -> None:
     )
 
 
+def test_serialize_time_dimension_group_by() -> None:
+    assert (
+        ADBCProtocol._serialize_val(
+            GroupByParam(name="time_dim", type=GroupByType.TIME_DIMENSION, grain="month"),
+        )
+        == 'TimeDimension("time_dim", "month")'
+    )
+    assert (
+        ADBCProtocol._serialize_val(
+            GroupByParam(name="time_dim", type=GroupByType.TIME_DIMENSION, grain="week"),
+        )
+        == 'TimeDimension("time_dim", "week")'
+    )
+
+
 def test_serialize_query_params_metrics() -> None:
     params = ADBCProtocol._serialize_params_dict({"metrics": ["a", "b"]}, ["metrics"])
 


### PR DESCRIPTION
In my original implementation, I assumed that `Dimension` was an alias for `TimeDimension`. I know we talked about doing that at some point, but I guess we never implemented that. So, this PR makes a distinction between `Dimension` and `TimeDimension` parameters.