### PR TITLE
feat: officially support Python 3.13

### DIFF
--- a/.changes/unreleased/Features-20250416-142848.yaml
+++ b/.changes/unreleased/Features-20250416-142848.yaml
@@ -1,0 +1,3 @@
+kind: Features
+body: Officially support Python 3.13
+time: 2025-04-16T14:28:48.910783+02:00

--- a/constraints/README.md
+++ b/constraints/README.md
@@ -2,6 +2,6 @@
 
 All files in this directory specify transitive dependency constraints for usage in our test environments. The files in this directory are _not_ shipped with the package, and users should specify those constraints themselves, according to what works in their own system. Learn more about pip constraints [here](https://pip.pypa.io/en/stable/user_guide/#constraints-files).
 
-This is useful for specifying different minimum versions of a package for Python 3.12 and 3.9, since older versions might not support the newest Python and vice-versa.
+This is useful for specifying different minimum versions of a package for Python 3.13 and 3.9, since older versions might not support the newest Python and vice-versa.
 
 For direct dependencies, we solve this by using the `python_version` [environment marker](https://peps.python.org/pep-0508/#environment-markers) in our dependencies.

--- a/constraints/py313.txt
+++ b/constraints/py313.txt
@@ -1,0 +1,7 @@
+numpy>=1.26.0,<2.0.0
+requests>=2.32.0
+urllib3>=1.26.8
+yarl>=1.9.3
+frozenlist>=1.5.0
+aiohttp>=3.9.0
+importlib-resources>=6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,15 +9,17 @@ authors = [
   {name = "dbt Labs"}
 ]
 readme = "README.md"
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.9,<3.14"
 dynamic = ["version"]
 
 dependencies = [
   "mashumaro>=3.11,<4.0",
   "typing-extensions>=4.4.0,<5.0.0; python_version<='3.11'",
-  "typing-extensions>=4.7.0,<5.0.0; python_version>= '3.12'",
+  "typing-extensions>=4.7.0,<5.0.0; python_version=='3.12'",
+  "typing-extensions>=4.12.0,<5.0.0; python_version>='3.13'",
   "pyarrow>=12.0.0; python_version<='3.11'",
-  "pyarrow>=14.0.0; python_version>='3.12'",
+  "pyarrow>=14.0.0; python_version=='3.12'",
+  "pyarrow>=18.0.0; python_version>='3.13'",
   "adbc-driver-flightsql>=0.11.0",
   "adbc-driver-manager>=0.11.0",
 ]
@@ -92,7 +94,7 @@ integration = "pytest tests/integration/ --server-schema tests/server_schema.gql
 # - Dependency resolution strategy (see UV_RESOLUTION in uv's manual)
 #   The SDK should work with a range of possible dependency versions
 [[tool.hatch.envs.test.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 deps-resolution = ["lowest", "lowest-direct", "highest"]
 
 [tool.hatch.envs.test.overrides]
@@ -101,6 +103,8 @@ matrix.python.env-vars = [
   { key = "UV_CONSTRAINT", value = "constraints/py310.txt", if = ["3.10"] },
   { key = "UV_CONSTRAINT", value = "constraints/py311.txt", if = ["3.11"] },
   { key = "UV_CONSTRAINT", value = "constraints/py312.txt", if = ["3.12"] },
+  { key = "UV_CONSTRAINT", value = "constraints/py313.txt", if = ["3.13"] },
+
 ]
 matrix.deps-resolution.env-vars = [
   { key = "UV_RESOLUTION" },


### PR DESCRIPTION
This commit adds support for Python 3.13 in the package metadata. There were no code changes required.

As usual, we had to add some constraints to our dependencies directly. Namely:
- `pyarrow` only supports Python 3.13 from v18.0.0 onwards
- `typing-extensions ` only supports Python 3.13 from v4.12.0 onwards

Direct dependencies are hard enforced by pip when installing the package, and users won't be able to install if their project requires an older version.

Additionally, I had to add constraints to two transitive dependencies:
- `frozenlist` only supports Python 3.13 from v1.5.0 onwards
- `importlib-resources` only supports Python 3.13 from v6.0.0 onwards

Transitive dependencies are NOT envorced by pip when installing the package, and users need to manually add constraints to them. This is not our problem: it's a problem with the dependency spec of downstream packages. This is why our `constraints/` folder exists.

All unit/integration tests are passing.