### PR TITLE
Fix: Make grain optional (default None) in GroupByParam

### DIFF
--- a/.changes/unreleased/Fixes-20260521-210810.yaml
+++ b/.changes/unreleased/Fixes-20260521-210810.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Make grain optional (default None) in GroupByParam so categorical group_by dimensions do not require a grain field
+time: 2026-05-21T21:08:10.518263-07:00

--- a/dbtsl/api/adbc/client/asyncio.py
+++ b/dbtsl/api/adbc/client/asyncio.py
@@ -1,6 +1,6 @@
 import asyncio
 from contextlib import asynccontextmanager
-from typing import AsyncIterator, Optional
+from typing import AsyncGenerator, Optional
 
 import pyarrow as pa
 from typing_extensions import Self, Unpack
@@ -34,7 +34,7 @@ class AsyncADBCClient(BaseADBCClient):
         self._loop = asyncio.get_running_loop()
 
     @asynccontextmanager
-    async def session(self) -> AsyncIterator[Self]:
+    async def session(self) -> AsyncGenerator[Self, None]:
         """Open a connection in the underlying ADBC driver.
 
         All requests made during the same session will reuse the same connection.

--- a/dbtsl/api/adbc/client/sync.py
+++ b/dbtsl/api/adbc/client/sync.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from typing import Iterator, Optional
+from typing import Generator, Optional
 
 import pyarrow as pa
 from typing_extensions import Self, Unpack
@@ -32,7 +32,7 @@ class SyncADBCClient(BaseADBCClient):
         super().__init__(server_host, environment_id, auth_token, url_format)
 
     @contextmanager
-    def session(self) -> Iterator[Self]:
+    def session(self) -> Generator[Self, None, None]:
         """Open a connection in the underlying ADBC driver.
 
         All requests made during the same session will reuse the same connection.

--- a/dbtsl/api/graphql/client/asyncio.py
+++ b/dbtsl/api/graphql/client/asyncio.py
@@ -2,7 +2,7 @@ import asyncio
 import time
 from builtins import TimeoutError as BuiltinTimeoutError
 from contextlib import asynccontextmanager
-from typing import AsyncIterator, Dict, Optional, Union
+from typing import AsyncGenerator, Dict, Optional, Union
 
 import pyarrow as pa
 from gql import gql
@@ -83,7 +83,7 @@ class AsyncGraphQLClient(BaseGraphQLClient[AIOHTTPTransport, AsyncClientSession]
         )
 
     @asynccontextmanager
-    async def session(self) -> AsyncIterator[Self]:
+    async def session(self) -> AsyncGenerator[Self, None]:
         """Open a session in the underlying aiohttp transport.
 
         A "session" is a TCP connection with the server. All operations

--- a/dbtsl/api/graphql/client/sync.py
+++ b/dbtsl/api/graphql/client/sync.py
@@ -1,6 +1,6 @@
 import time
 from contextlib import contextmanager
-from typing import Dict, Iterator, Optional, Union
+from typing import Dict, Generator, Optional, Union
 
 import pyarrow as pa
 from gql import gql
@@ -71,7 +71,7 @@ class SyncGraphQLClient(BaseGraphQLClient[RequestsHTTPTransport, SyncClientSessi
         )
 
     @contextmanager
-    def session(self) -> Iterator[Self]:
+    def session(self) -> Generator[Self, None, None]:
         """Open a session in the underlying requests transport.
 
         A "session" is a TCP connection with the server. All operations

--- a/dbtsl/api/shared/query_params.py
+++ b/dbtsl/api/shared/query_params.py
@@ -17,7 +17,7 @@ class GroupByParam:
 
     name: str
     type: GroupByType
-    grain: Optional[str]
+    grain: Optional[str] = None
 
 
 @dataclass(frozen=True)

--- a/dbtsl/client/asyncio.py
+++ b/dbtsl/client/asyncio.py
@@ -1,5 +1,5 @@
 from contextlib import asynccontextmanager
-from typing import AsyncIterator, Optional, Union
+from typing import AsyncGenerator, Optional, Union
 
 from typing_extensions import Self
 
@@ -49,7 +49,7 @@ class AsyncSemanticLayerClient(BaseSemanticLayerClient[AsyncGraphQLClient, Async
         )
 
     @asynccontextmanager
-    async def session(self) -> AsyncIterator[Self]:
+    async def session(self) -> AsyncGenerator[Self, None]:
         """Establish a connection with the dbt Semantic Layer's servers."""
         if self._has_session:
             raise ValueError("Cannot open session within session.")

--- a/dbtsl/client/sync.py
+++ b/dbtsl/client/sync.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from typing import Iterator, Optional, Union
+from typing import Generator, Optional, Union
 
 from typing_extensions import Self
 
@@ -49,7 +49,7 @@ class SyncSemanticLayerClient(BaseSemanticLayerClient[SyncGraphQLClient, SyncADB
         )
 
     @contextmanager
-    def session(self) -> Iterator[Self]:
+    def session(self) -> Generator[Self, None, None]:
         """Establish a connection with the dbt Semantic Layer's servers."""
         if self._has_session:
             raise ValueError("Cannot open session within session.")

--- a/tests/query_test_cases.py
+++ b/tests/query_test_cases.py
@@ -54,6 +54,6 @@ TEST_QUERIES: List[QueryParameters] = [
     # group by param object without grain (categorical dimension)
     {
         "metrics": ["order_total"],
-        "group_by": [GroupByParam(name="business_owner__acquisition_channel", type=GroupByType.DIMENSION)],
+        "group_by": [GroupByParam(name="customer__customer_type", type=GroupByType.DIMENSION)],
     },
 ]

--- a/tests/query_test_cases.py
+++ b/tests/query_test_cases.py
@@ -51,4 +51,9 @@ TEST_QUERIES: List[QueryParameters] = [
             GroupByParam(name="metric_time", grain="week", type=GroupByType.DIMENSION),
         ],
     },
+    # group by param object without grain (categorical dimension)
+    {
+        "metrics": ["order_total"],
+        "group_by": [GroupByParam(name="business_owner__acquisition_channel", type=GroupByType.DIMENSION)],
+    },
 ]


### PR DESCRIPTION
Addressing an issue surfaced in [#project-mcp](https://dbt-labs.slack.com/archives/C08GXNELQV7/p1779407930101869) and related to dbt MCP issue [#260](https://github.com/dbt-labs/dbt-mcp/issues/260).

WHY:
`GroupByParam` has `grain: Optional[str]` with no default value. Python dataclasses treat any field without a default as positionally required so when FastMCP/Pydantic generates the JSON Schema for tools that accept `list[GroupByParam]`, grain appears in the required array.... even though the type annotation allows null.                      

This causes tools like `query_metrics` and `get_metrics_compiled_sql` in dbt MCP to fail immediately with 'grain' as a required property when a categorical dimension is passed without a grain.

The issue was previously worked around in dbt-mcp by [changing the tool prompts](https://github.com/dbt-labs/dbt-mcp/pull/281). This was done by adding `"grain": null` to examples, but that approach wasn't airtight and the root cause was never addressed in the SDK. 
                                                                                                                                                                                                                                
VALIDATION:

I made this change locally, pointed my local dev dbt MCP to the local source build of my SL SDK python dev branch, and then ran the dbt MCP hitting both `query_metrics` and `get_metrics_compiled_sql`:

<img width="1579" height="282" alt="Screenshot 2026-05-21 at 9 26 09 PM" src="https://github.com/user-attachments/assets/fbc60cc1-f8d1-4a13-a45c-47ea42a9956b" />

Got solid results here. 